### PR TITLE
task #9 Dependency 플러그인 정의

### DIFF
--- a/IOS08Shook/Sources/ContentView.swift
+++ b/IOS08Shook/Sources/ContentView.swift
@@ -5,9 +5,9 @@ import SwiftUI
 public struct ContentView: View {
     public init() {}
 
-        public var body: some View {
-            Text("Hello, World!")
-                .padding()
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
     }
 }
 

--- a/Plugin/DependencyPlugin/Plugin.swift
+++ b/Plugin/DependencyPlugin/Plugin.swift
@@ -1,0 +1,2 @@
+import ProjectDescription
+let dependencyPlugin = Plugin(name: "DependencyPlugin")

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ModularTarget.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+ModularTarget.swift
@@ -1,0 +1,45 @@
+import Foundation
+import ProjectDescription
+
+public extension TargetDependency {
+    static func feature(
+        target: ModulePaths.Feature,
+        type: MoudlarTargetType = .sources
+    ) -> TargetDependency {
+        .project(
+            target: target.targetName(type: type),
+            path: .relativeToFeature(target.rawValue)
+        )
+    }
+    
+    static func module(
+        target: ModulePaths.Module,
+        type: MoudlarTargetType = .sources
+    ) -> TargetDependency {
+        .project(
+            target: target.targetName(type: type),
+            path: .relativeToModule(target.rawValue)
+        )
+    }
+    
+    static func domain(
+        target: ModulePaths.Domain,
+        type: MoudlarTargetType = .sources
+    ) -> TargetDependency {
+        .project(
+            target: target.targetName(type: type),
+            path: .relativeToDomain(target.rawValue)
+        )
+    }
+
+    static func userInterface(
+        target: ModulePaths.UserInterface,
+        type: MoudlarTargetType = .sources
+    ) -> TargetDependency {
+        .project(
+            target: target.targetName(type: type),
+            path: .relativeToUserInterfaces(target.rawValue)
+        )
+    }
+
+}

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -1,0 +1,11 @@
+import ProjectDescription
+
+public extension TargetDependency {
+    struct SPM {}
+}
+
+public extension TargetDependency.SPM {
+    // MARK: external
+    
+    // ex) static let Moya = TargetDependency.external(name: "Moya")
+}

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+public enum ModulePaths {
+    case feature(Feature)
+    case module(Module)
+    case domain(Domain)
+    case userInterface(UserInterface)
+    
+}
+
+extension ModulePaths: ModularPathConvertable {
+    public func targetName(type: MoudlarTargetType) -> String {
+        switch self {
+        case let .feature(module as any ModularPathConvertable),
+            let .module(module as any ModularPathConvertable),
+            let .domain(module as any ModularPathConvertable),
+            let .userInterface(module as any ModularPathConvertable):
+            return module.targetName(type: type)
+        }
+    }
+}
+
+public extension ModulePaths {
+    enum Feature: String, ModularPathConvertable {
+        case BaseFeature
+        
+    }
+}
+
+public extension ModulePaths {
+    enum Module: String, ModularPathConvertable {
+        case ThirdPartyLibModule
+    }
+}
+
+public extension ModulePaths {
+    enum Domain: String, ModularPathConvertable {
+        case BaseDomain
+    }
+}
+
+
+public extension ModulePaths {
+    enum UserInterface: String, ModularPathConvertable {
+        case DesignSystem
+    }
+}
+
+public enum MoudlarTargetType: String {
+    case interface = "Interface"
+    case sources = ""
+    case testing = "Testing"
+    case unitTest = "Tests"
+    case demo = "Demo"
+}
+
+public protocol ModularPathConvertable {
+    func targetName(type: MoudlarTargetType) -> String
+}
+
+public extension ModularPathConvertable where Self: RawRepresentable {
+    func targetName(type: MoudlarTargetType) -> String {
+        "\(self.rawValue)\(type.rawValue)"
+    }
+}

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/PathExtension.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/PathExtension.swift
@@ -1,0 +1,31 @@
+import ProjectDescription
+
+public extension ProjectDescription.Path {
+    static func relativeToFeature(_ path: String) -> Self {
+        return .relativeToRoot("Projects/Features/\(path)")
+    }
+    
+    static func relativeToModule(_ path: String) -> Self {
+            return .relativeToRoot("Projects/Modules/\(path)")
+    }
+    
+    static func relativeToDomain(_ path: String) -> Self {
+        return .relativeToRoot("Projects/Domains/\(path)")
+    }
+    
+    static func relativeToUserInterfaces(_ path: String) -> Self {
+        return .relativeToRoot("Projects/UserInterfaces/\(path)")
+    }
+    
+    static var scripts: Self {
+        return .relativeToRoot("Scripts")
+    }
+    
+    static var app: Self {
+        return .relativeToRoot("Projects/App")
+    }
+    
+    static func + (lhs: Self, rhs: String) -> Self {
+        return Path.relativeToRoot(lhs.pathString + rhs)
+    }
+}

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -2,6 +2,7 @@ import ProjectDescription
 
 let config = Config(
     plugins: [    
+		.local(path: .relativeToRoot("Plugin/DependencyPlugin")),    
 		.local(path: .relativeToRoot("Plugin/ConfigurationPlugin")),
     ],
     generationOptions: .options()


### PR DESCRIPTION
## 💡 요약 및 이슈 

### Dependency 플러그인을 정의했습니다.

Resolves: #9 

## 📃 작업내용

- Path 의존성 정의
- SPM 의존성 정의

각종 의존성을 다루는 플러그인을 정의했습니다.

## 🙋‍♂️ 리뷰노트

- 없습니다.

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?
