### PR TITLE
task #48 요청 오류 적용

### DIFF
--- a/Projects/Modules/NetworkModule/Sources/Request/Encoding/ParamterJSONEncoder.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/Encoding/ParamterJSONEncoder.swift
@@ -8,7 +8,7 @@ public struct ParamterJSONEncoder: RequestParameterEncodable {
             request.httpBody = jsonData
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         } catch {
-            throw RequestError.jsonSerializationFailed(error)
+            throw RequestError.jsonEncodingFailed(error)
         }
     }
     

--- a/Projects/Modules/NetworkModule/Sources/Request/Encoding/ParamterJSONEncoder.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/Encoding/ParamterJSONEncoder.swift
@@ -8,7 +8,7 @@ public struct ParamterJSONEncoder: RequestParameterEncodable {
             request.httpBody = jsonData
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         } catch {
-            #warning("인코딩 에러")
+            throw RequestError.jsonSerializationFailed(error)
         }
     }
     

--- a/Projects/Modules/NetworkModule/Sources/Request/Encoding/URLQueryEncoder.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/Encoding/URLQueryEncoder.swift
@@ -2,10 +2,9 @@ import Foundation
 
 public struct URLQueryEncoder: RequestParameterEncodable {
     
-#warning("배열 query value는 추후 구현")
+    #warning("배열 query value는 추후 구현")
     func encode(request: inout URLRequest, with parameters: Parameters) throws {
-        #warning("return을 에러로 교체")
-        guard let url = request.url else { return }
+        guard let url = request.url else { throw RequestError.missingURL }
         
         if var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false), !parameters.isEmpty {
             urlComponents.queryItems = parameters.map {

--- a/Projects/Modules/NetworkModule/Sources/Request/RequestError.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/RequestError.swift
@@ -8,7 +8,8 @@ enum RequestError: Error, LocalizedError {
         switch self {
         case .missingURL:
             return "요청에서 유효한 URL을 찾을 수 없습니다."
-        case .jsonEncodingFailed(let error):
+            
+        case let .jsonEncodingFailed(error):
             return "JSON 인코딩에 실패했습니다: \(error.localizedDescription)"
         }
     }

--- a/Projects/Modules/NetworkModule/Sources/Request/RequestError.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/RequestError.swift
@@ -2,14 +2,14 @@ import Foundation
 
 enum RequestError: Error, LocalizedError {
     case missingURL
-    case jsonSerializationFailed(Error)
+    case jsonEncodingFailed(Error)
     
     var errorDescription: String? {
         switch self {
         case .missingURL:
             return "요청에서 유효한 URL을 찾을 수 없습니다."
-        case .jsonSerializationFailed(let error):
-            return "JSON 직렬화에 실패했습니다: \(error.localizedDescription)"
+        case .jsonEncodingFailed(let error):
+            return "JSON 인코딩에 실패했습니다: \(error.localizedDescription)"
         }
     }
 }

--- a/Projects/Modules/NetworkModule/Sources/Request/RequestError.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/RequestError.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum RequestError: Error, LocalizedError {
+    case missingURL
+    case jsonSerializationFailed(Error)
+    
+    var errorDescription: String? {
+        switch self {
+        case .missingURL:
+            return "요청에서 유효한 URL을 찾을 수 없습니다."
+        case .jsonSerializationFailed(let error):
+            return "JSON 직렬화에 실패했습니다: \(error.localizedDescription)"
+        }
+    }
+}


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 요청 오류를 정의하고 적용했습니다.

Resolves: #48 

## 📃 작업내용

- `RequestError` 생성
- `RequestError` 적용

## 🙋‍♂️ 리뷰노트

- `RequestError` 네이밍 리뷰 요청드립니다.
- 처음에는 `invalidURL`, `invalidJSONSerialization`으로 했지만 조금더 명확한 오류명이 좋을 것 같아 아래와 같이 네이밍을 지었습니다.

```swift
enum RequestError: Error, LocalizedError {
    case missingURL
    case jsonSerializationFailed(Error)
    
    var errorDescription: String? {
        switch self {
        case .missingURL:
            return "요청에서 유효한 URL을 찾을 수 없습니다."
        case .jsonSerializationFailed(let error):
            return "JSON 직렬화에 실패했습니다: \(error.localizedDescription)"
        }
    }
}
```

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?