### PR TITLE
task #39 RequstTask별 알맞은 reuqst param을 적용

### DIFF
--- a/Projects/Modules/NetworkModule/Sources/Request/Encoding/ParamterJSONEncoder.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/Encoding/ParamterJSONEncoder.swift
@@ -13,3 +13,9 @@ public struct ParamterJSONEncoder: RequestParameterEncodable {
     }
     
 }
+
+public extension RequestParameterEncodable where Self == ParamterJSONEncoder {
+    static func json() -> ParamterJSONEncoder {
+        ParamterJSONEncoder()
+    }
+}

--- a/Projects/Modules/NetworkModule/Sources/Request/Encoding/ParamterJSONEncoder.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/Encoding/ParamterJSONEncoder.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct ParamterJSONEncoder: RequestParameterEncodable {
     
-    func encode(request: inout URLRequest, with parameters: Parameters) throws {
+    public func encode(request: inout URLRequest, with parameters: Parameters) throws {
         do {
             let jsonData = try JSONSerialization.data(withJSONObject: parameters, options: [])
             request.httpBody = jsonData

--- a/Projects/Modules/NetworkModule/Sources/Request/Encoding/ParamterJSONEncoder.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/Encoding/ParamterJSONEncoder.swift
@@ -15,7 +15,7 @@ public struct ParamterJSONEncoder: RequestParameterEncodable {
 }
 
 public extension RequestParameterEncodable where Self == ParamterJSONEncoder {
-    static func json() -> ParamterJSONEncoder {
+    static var json: ParamterJSONEncoder {
         ParamterJSONEncoder()
     }
 }

--- a/Projects/Modules/NetworkModule/Sources/Request/Encoding/RequestParameterEncodable.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/Encoding/RequestParameterEncodable.swift
@@ -3,6 +3,7 @@ import UIKit
 
 public typealias Parameters = [String: Any]
 
-protocol RequestParameterEncodable {
+public protocol RequestParameterEncodable {
     func encode(request: inout URLRequest, with parameters: Parameters) throws
 }
+

--- a/Projects/Modules/NetworkModule/Sources/Request/Encoding/URLQueryEncoder.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/Encoding/URLQueryEncoder.swift
@@ -21,3 +21,9 @@ private extension String {
         self.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
     }
 }
+
+extension RequestParameterEncodable where Self == URLQueryEncoder {
+    static func query() -> URLQueryEncoder {
+        URLQueryEncoder()
+    }
+}

--- a/Projects/Modules/NetworkModule/Sources/Request/Encoding/URLQueryEncoder.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/Encoding/URLQueryEncoder.swift
@@ -23,7 +23,7 @@ private extension String {
 }
 
 public extension RequestParameterEncodable where Self == URLQueryEncoder {
-    static func query() -> URLQueryEncoder {
+    static var query: URLQueryEncoder {
         URLQueryEncoder()
     }
 }

--- a/Projects/Modules/NetworkModule/Sources/Request/Encoding/URLQueryEncoder.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/Encoding/URLQueryEncoder.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct URLQueryEncoder: RequestParameterEncodable {
     
 #warning("배열 query value는 추후 구현")
-    func encode(request: inout URLRequest, with parameters: Parameters) throws {
+    public func encode(request: inout URLRequest, with parameters: Parameters) throws {
         #warning("return을 에러로 교체")
         guard let url = request.url else { return }
         
@@ -22,7 +22,7 @@ private extension String {
     }
 }
 
-extension RequestParameterEncodable where Self == URLQueryEncoder {
+public extension RequestParameterEncodable where Self == URLQueryEncoder {
     static func query() -> URLQueryEncoder {
         URLQueryEncoder()
     }

--- a/Projects/Modules/NetworkModule/Sources/Request/RequestTask.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/RequestTask.swift
@@ -5,13 +5,13 @@ public enum RequestTask {
     case withParamteres(
         body: Parameters? = nil,
         query: Parameters? = nil,
-        bodyEncoder: any RequestParameterEncodable = .json(),
-        urlqueryEncoder: any RequestParameterEncodable = .query()
+        bodyEncoder: any RequestParameterEncodable = .json,
+        urlqueryEncoder: any RequestParameterEncodable = .query
     )
     case withObject(
         body: any Encodable,
         query: Parameters? = nil,
-        urlqueryEncoder: any RequestParameterEncodable = .query()
+        urlqueryEncoder: any RequestParameterEncodable = .query
     )
 }
 

--- a/Projects/Modules/NetworkModule/Sources/Request/RequestTask.swift
+++ b/Projects/Modules/NetworkModule/Sources/Request/RequestTask.swift
@@ -2,7 +2,60 @@ import Foundation
 
 public enum RequestTask {
     case empty
-    case query(parameters: Parameters)
-    case bodyByObject(object: any Encodable)
-    case bodyByParameters(parameters: Parameters)
+    case withParamteres(
+        body: Parameters? = nil,
+        query: Parameters? = nil,
+        bodyEncoder: any RequestParameterEncodable = .json(),
+        urlqueryEncoder: any RequestParameterEncodable = .query()
+    )
+    case withObject(
+        body: any Encodable,
+        query: Parameters? = nil,
+        urlqueryEncoder: any RequestParameterEncodable = .query()
+    )
+}
+
+extension RequestTask {
+    func configureRequest(request: inout URLRequest) throws {
+        switch self {
+        case .empty:
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        case let .withParamteres(body, query, bodyEncoder, urlqueryEncoder):
+            try configureParam(request: &request, body: body, query: query, bodyEncoder: bodyEncoder, urlqueryEncoder: urlqueryEncoder)
+        
+        case let .withObject(body, query, urlqueryEncoder):
+            try configureObject(request: &request, body: body, query: query, urlqueryEncoder: urlqueryEncoder)
+        }
+    }
+    
+    func configureParam(
+        request: inout URLRequest,
+        body: Parameters?,
+        query: Parameters?,
+        bodyEncoder: any RequestParameterEncodable,
+        urlqueryEncoder: any RequestParameterEncodable
+    ) throws {
+        if let body {
+            try bodyEncoder.encode(request: &request, with: body)
+        }
+        
+        if let query {
+            try urlqueryEncoder.encode(request: &request, with: query)
+        }
+    }
+        
+    func configureObject(
+        request: inout URLRequest,
+        body: any Encodable,
+        query: Parameters?,
+        urlqueryEncoder: any RequestParameterEncodable
+    ) throws {
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+        
+        if let query {
+            try urlqueryEncoder.encode(request: &request, with: query)
+        }
+    }
 }

--- a/Projects/Modules/NetworkModule/Tests/NetworkModuleTest.swift
+++ b/Projects/Modules/NetworkModule/Tests/NetworkModuleTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import NetworkModule
 
-struct Body: Encodable {
+private struct Body: Encodable {
     let name: String
 }
 


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 파라미터 또는 객체로 들어오는 데이터를 reuqst에 알맞게 실어줍니다.


Resolves: #39 

## 📃 작업내용

### RqustTask 의 case를 수정합니다.
- query파라미터와 body 데이터는 동시에 들어올 수 있으므로 구조 개선을 진행했습니다.

### case에 맞게 requst configuration을 적용합니다.


## 🙋‍♂️ 리뷰노트

- 없습니다.

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
