### PR TITLE
task #54 뷰 center 배치 기능 구현

### DIFF
--- a/Projects/Modules/EasyLayoutModule/Demo/Sources/ViewController.swift
+++ b/Projects/Modules/EasyLayoutModule/Demo/Sources/ViewController.swift
@@ -17,6 +17,13 @@ final class EasyLayoutDemoViewController: UIViewController {
         return view
     }()
     
+    private let thirdView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .blue
+        view.frame.origin = CGPoint(x: 0, y: 0)
+        return view
+    }()
+    
     init() {
         super.init(nibName: nil, bundle: nil)
     }
@@ -36,8 +43,8 @@ final class EasyLayoutDemoViewController: UIViewController {
     
     private func setupSubViewsConstraints() {
         view.addSubview(firstView)
-        
         view.addSubview(secondView)
+        view.addSubview(thirdView)
         
         firstView.ezl.makeConstraint {
             $0.top(to: view.safeAreaLayoutGuide.ezl.top)
@@ -49,6 +56,11 @@ final class EasyLayoutDemoViewController: UIViewController {
             $0.top(to: firstView.ezl.bottom)
                 .horizontal(to: view)
                 .height(200)
+        }
+        
+        thirdView.ezl.makeConstraint {
+            $0.center(to: view)
+                .size(with: 200)
         }
     }
 }

--- a/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
@@ -9,6 +9,7 @@ public struct EasyConstraint {
         view.translatesAutoresizingMaskIntoConstraints = false
     }
     
+    // MARK: About Size
     @discardableResult
     public func width(_ width: CGFloat) -> Self {
         baseView.widthAnchor.constraint(equalToConstant: width).isActive = true
@@ -26,6 +27,7 @@ public struct EasyConstraint {
         width(size).height(size)
     }
     
+    // MARK: About Position
     @discardableResult
     public func top(to anchor: YAnchor) -> Self {
         baseView.topAnchor.constraint(equalTo: anchor.standard).isActive = true

--- a/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
@@ -67,9 +67,16 @@ public struct EasyConstraint {
         top(to: view.ezl.top).bottom(to: view.ezl.bottom).leading(to: view.ezl.leading).trailing(to: view.ezl.trailing)
     }
     
+    // MARK: About Center
     @discardableResult
     public func centerX(to view: Anchorable) -> Self {
         baseView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        return self
+    }
+    
+    @discardableResult
+    public func centerY(to view: Anchorable) -> Self {
+        baseView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
         return self
     }
 }

--- a/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
@@ -79,4 +79,9 @@ public struct EasyConstraint {
         baseView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
         return self
     }
+    
+    @discardableResult
+    public func center(to view: Anchorable) -> Self {
+        centerX(to: view).centerY(to: view)
+    }
 }

--- a/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
@@ -64,4 +64,10 @@ public struct EasyConstraint {
     public func diagonal(to view: Anchorable) -> Self {
         top(to: view.ezl.top).bottom(to: view.ezl.bottom).leading(to: view.ezl.leading).trailing(to: view.ezl.trailing)
     }
+    
+    @discardableResult
+    public func centerX(to view: Anchorable) -> Self {
+        baseView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        return self
+    }
 }

--- a/Projects/Modules/EasyLayoutModule/Sources/Protocol/Anchorable.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/Protocol/Anchorable.swift
@@ -8,6 +8,7 @@ public protocol Anchorable {
     var widthAnchor: NSLayoutDimension { get }
     var heightAnchor: NSLayoutDimension { get }
     var centerXAnchor: NSLayoutXAxisAnchor { get }
+    var centerYAnchor: NSLayoutYAxisAnchor { get }
 }
 
 extension Anchorable {

--- a/Projects/Modules/EasyLayoutModule/Sources/Protocol/Anchorable.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/Protocol/Anchorable.swift
@@ -7,6 +7,7 @@ public protocol Anchorable {
     var trailingAnchor: NSLayoutXAxisAnchor { get }
     var widthAnchor: NSLayoutDimension { get }
     var heightAnchor: NSLayoutDimension { get }
+    var centerXAnchor: NSLayoutXAxisAnchor { get }
 }
 
 extension Anchorable {


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 뷰의 위치를 특정뷰 center에 배치하는 기능을 구현했습니다.

Resolves: #54

## 📃 작업내용

- 뷰의 위치를 특정뷰 center(정가운데) 배치하는 기능
- 뷰의 위치를 특정뷰 centerX에 배치하는 기능
- 뷰의 위치를 특정뷰 centerY에 배치하는 기능

![스크린샷 2024-11-14 오후 4 35 18](https://github.com/user-attachments/assets/8044266c-7420-438c-a841-f0e2d8928eb5)


## 🙋‍♂️ 리뷰노트

1. centerX와 centerHorizontal 중 네이밍을 고민했습니다.
   a. UIView의 프로퍼티명이 centerXAnchor로 설정되어 있어 통일성을 맞추기 위해 centerX를 사용했습니다.

## ✅ PR 체크리스트


- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
