### PR TITLE
task #63 offset & padding 파라미터 추가

### DIFF
--- a/Projects/Modules/EasyLayoutModule/Demo/Sources/ViewController.swift
+++ b/Projects/Modules/EasyLayoutModule/Demo/Sources/ViewController.swift
@@ -54,13 +54,12 @@ final class EasyLayoutDemoViewController: UIViewController {
         
         secondView.ezl.makeConstraint {
             $0.top(to: firstView.ezl.bottom)
-                .horizontal(to: view)
+                .horizontal(to: view, padding: 40)
                 .height(200)
         }
         
         thirdView.ezl.makeConstraint {
-            $0.center(to: view)
-                .size(with: 200)
+            $0.diagonal(to: view.safeAreaLayoutGuide, padding: 50)
         }
     }
 }

--- a/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
@@ -29,42 +29,57 @@ public struct EasyConstraint {
     
     // MARK: About Position
     @discardableResult
-    public func top(to anchor: YAnchor) -> Self {
-        baseView.topAnchor.constraint(equalTo: anchor.standard).isActive = true
+    public func top(to anchor: YAnchor, offset: CGFloat = 0) -> Self {
+        baseView.topAnchor.constraint(
+            equalTo: anchor.standard,
+            constant: offset
+        ).isActive = true
         return self
     }
     
     @discardableResult
-    public func bottom(to anchor: YAnchor) -> Self {
-        baseView.bottomAnchor.constraint(equalTo: anchor.standard).isActive = true
+    public func bottom(to anchor: YAnchor, offset: CGFloat = 0) -> Self {
+        baseView.bottomAnchor.constraint(
+            equalTo: anchor.standard,
+            constant: offset
+        ).isActive = true
         return self
     }
     
     @discardableResult
-    public func leading(to anchor: XAnchor) -> Self {
-        baseView.leadingAnchor.constraint(equalTo: anchor.standard).isActive = true
+    public func leading(to anchor: XAnchor, offset: CGFloat = 0) -> Self {
+        baseView.leadingAnchor.constraint(
+            equalTo: anchor.standard,
+            constant: offset
+        ).isActive = true
         return self
     }
     
     @discardableResult
-    public func trailing(to anchor: XAnchor) -> Self {
-        baseView.trailingAnchor.constraint(equalTo: anchor.standard).isActive = true
+    public func trailing(to anchor: XAnchor, offset: CGFloat = 0) -> Self {
+        baseView.trailingAnchor.constraint(
+            equalTo: anchor.standard,
+            constant: offset
+        ).isActive = true
         return self
     }
     
     @discardableResult
-    public func horizontal(to view: Anchorable) -> Self {
-        leading(to: view.ezl.leading).trailing(to: view.ezl.trailing)
+    public func horizontal(to view: Anchorable, padding: CGFloat = 0.0) -> Self {
+        leading(to: view.ezl.leading, offset: padding)
+            .trailing(to: view.ezl.trailing, offset: padding * -1)
     }
     
     @discardableResult
-    public func vertical(to view: Anchorable) -> Self {
-        top(to: view.ezl.top).bottom(to: view.ezl.bottom)
+    public func vertical(to view: Anchorable, padding: CGFloat = 0.0) -> Self {
+        top(to: view.ezl.top, offset: padding)
+            .bottom(to: view.ezl.bottom, offset: padding * -1)
     }
     
     @discardableResult
-    public func diagonal(to view: Anchorable) -> Self {
-        top(to: view.ezl.top).bottom(to: view.ezl.bottom).leading(to: view.ezl.leading).trailing(to: view.ezl.trailing)
+    public func diagonal(to view: Anchorable, padding: CGFloat = 0.0) -> Self {
+        horizontal(to: view, padding: padding)
+            .vertical(to: view, padding: padding)
     }
     
     // MARK: About Center


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 여백 설정을 위한 offset & padding 파라미터 추가

Resolves: #63

## 📃 작업내용

- offset & padding 파라미터 추가

## 🙋‍♂️ 리뷰노트

- top, bottom, leading, tailing의 경우 offset으로 부호 처리 없이 layout의 constant 값으로 설정됩니다.
- horizontal, vertical, diagonal의 경우 padding으로 tailing, bottom의 constant 값으로 부호가 음수로 변환되어 설정 됩니다.

![스크린샷 2024-11-14 오후 9 30 44](https://github.com/user-attachments/assets/859fafc9-161b-4ebb-b04d-b5286bd52a7a)


## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
