### PR TITLE
task #74 Anchor enum -> struct로 변경

### DIFF
--- a/Projects/Modules/EasyLayoutModule/Sources/Anchor.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/Anchor.swift
@@ -1,27 +1,51 @@
 import UIKit
 
 // MARK: YAnchor
-public enum YAnchor {
-    case top(Anchorable)
-    case bottom(Anchorable)
-    
-    var standard: NSLayoutYAxisAnchor {
-        switch self {
-        case let .top(view): view.topAnchor
-        case let .bottom(view): view.bottomAnchor
+public struct YAnchor {
+    enum `Type` {
+        case top(Anchorable)
+        case bottom(Anchorable)
+        
+        var standard: NSLayoutYAxisAnchor {
+            switch self {
+            case let .top(view): view.topAnchor
+            case let .bottom(view): view.bottomAnchor
+            }
         }
+    }
+    
+    let type: `Type`
+    
+    static func top(_ view: Anchorable) -> Self {
+        YAnchor(type: .top(view))
+    }
+    
+    static func bottom(_ view: Anchorable) -> Self {
+        YAnchor(type: .bottom(view))
     }
 }
 
 // MARK: XAnchor
-public enum XAnchor {
-    case leading(Anchorable)
-    case trailing(Anchorable)
-    
-    var standard: NSLayoutXAxisAnchor {
-        switch self {
-        case let .leading(view): view.leadingAnchor
-        case let .trailing(view): view.trailingAnchor
+public struct XAnchor {
+    enum `Type` {
+        case leading(Anchorable)
+        case trailing(Anchorable)
+        
+        var standard: NSLayoutXAxisAnchor {
+            switch self {
+            case let .leading(view): view.leadingAnchor
+            case let .trailing(view): view.trailingAnchor
+            }
         }
+    }
+    
+    let type: `Type`
+    
+    static func leading(_ view: Anchorable) -> Self {
+        XAnchor(type: .leading(view))
+    }
+    
+    static func trailing(_ view: Anchorable) -> Self {
+        XAnchor(type: .trailing(view))
     }
 }

--- a/Projects/Modules/EasyLayoutModule/Sources/Anchor.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/Anchor.swift
@@ -2,7 +2,7 @@ import UIKit
 
 // MARK: YAnchor
 public struct YAnchor {
-    enum `Type` {
+    enum Edge {
         case top(Anchorable)
         case bottom(Anchorable)
         
@@ -14,20 +14,20 @@ public struct YAnchor {
         }
     }
     
-    let type: `Type`
+    let edge: Edge
     
     static func top(_ view: Anchorable) -> Self {
-        YAnchor(type: .top(view))
+        YAnchor(edge: .top(view))
     }
     
     static func bottom(_ view: Anchorable) -> Self {
-        YAnchor(type: .bottom(view))
+        YAnchor(edge: .bottom(view))
     }
 }
 
 // MARK: XAnchor
 public struct XAnchor {
-    enum `Type` {
+    enum Edge {
         case leading(Anchorable)
         case trailing(Anchorable)
         
@@ -39,13 +39,13 @@ public struct XAnchor {
         }
     }
     
-    let type: `Type`
+    let edge: Edge
     
     static func leading(_ view: Anchorable) -> Self {
-        XAnchor(type: .leading(view))
+        XAnchor(edge: .leading(view))
     }
     
     static func trailing(_ view: Anchorable) -> Self {
-        XAnchor(type: .trailing(view))
+        XAnchor(edge: .trailing(view))
     }
 }

--- a/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
@@ -31,7 +31,7 @@ public struct EasyConstraint {
     @discardableResult
     public func top(to anchor: YAnchor, offset: CGFloat = 0) -> Self {
         baseView.topAnchor.constraint(
-            equalTo: anchor.type.standard,
+            equalTo: anchor.edge.standard,
             constant: offset
         ).isActive = true
         return self
@@ -40,7 +40,7 @@ public struct EasyConstraint {
     @discardableResult
     public func bottom(to anchor: YAnchor, offset: CGFloat = 0) -> Self {
         baseView.bottomAnchor.constraint(
-            equalTo: anchor.type.standard,
+            equalTo: anchor.edge.standard,
             constant: offset
         ).isActive = true
         return self
@@ -49,7 +49,7 @@ public struct EasyConstraint {
     @discardableResult
     public func leading(to anchor: XAnchor, offset: CGFloat = 0) -> Self {
         baseView.leadingAnchor.constraint(
-            equalTo: anchor.type.standard,
+            equalTo: anchor.edge.standard,
             constant: offset
         ).isActive = true
         return self
@@ -58,7 +58,7 @@ public struct EasyConstraint {
     @discardableResult
     public func trailing(to anchor: XAnchor, offset: CGFloat = 0) -> Self {
         baseView.trailingAnchor.constraint(
-            equalTo: anchor.type.standard,
+            equalTo: anchor.edge.standard,
             constant: offset
         ).isActive = true
         return self

--- a/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
@@ -31,7 +31,7 @@ public struct EasyConstraint {
     @discardableResult
     public func top(to anchor: YAnchor, offset: CGFloat = 0) -> Self {
         baseView.topAnchor.constraint(
-            equalTo: anchor.standard,
+            equalTo: anchor.type.standard,
             constant: offset
         ).isActive = true
         return self
@@ -40,7 +40,7 @@ public struct EasyConstraint {
     @discardableResult
     public func bottom(to anchor: YAnchor, offset: CGFloat = 0) -> Self {
         baseView.bottomAnchor.constraint(
-            equalTo: anchor.standard,
+            equalTo: anchor.type.standard,
             constant: offset
         ).isActive = true
         return self
@@ -49,7 +49,7 @@ public struct EasyConstraint {
     @discardableResult
     public func leading(to anchor: XAnchor, offset: CGFloat = 0) -> Self {
         baseView.leadingAnchor.constraint(
-            equalTo: anchor.standard,
+            equalTo: anchor.type.standard,
             constant: offset
         ).isActive = true
         return self
@@ -58,7 +58,7 @@ public struct EasyConstraint {
     @discardableResult
     public func trailing(to anchor: XAnchor, offset: CGFloat = 0) -> Self {
         baseView.trailingAnchor.constraint(
-            equalTo: anchor.standard,
+            equalTo: anchor.type.standard,
             constant: offset
         ).isActive = true
         return self


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 상대 뷰의 top, bottom, leadiing, tailing 기준면 설정 방식 통일

Resolves: #74 

## 📃 작업내용

상대 뷰의 top, bottom, leading, tailing 기준면을 선택할 때

```swift
firstView.ezl.makeConstraint {
    $0.top(to: view.safeAreaLayoutGuide.ezl.top)
}
```
```swift
firstView.ezl.makeConstraint {
    $0.top(to: .top(view.safeAreaLayoutGuide))
}
```
위 두 가지 방법으로 설정할 수 있습니다. 통일성을 위해

```swift
firstView.ezl.makeConstraint {
    $0.top(to: view.safeAreaLayoutGuide.ezl.top)
}
```
해당 방법으로만 기준면을 설정할 수 있도록 `YAnchor`, `XAnchor`을 enum에서 struct로 변경 및 중첩 타입 사용



## 🙋‍♂️ 리뷰노트

`YAnchor`, `XAnchor` 중첩 enum 타입의 네이밍으로 `Type`을 사용했는데 괜찮은가요?

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
