### PR TITLE
task #75 Anchorable 타입을 파라미터로 받을 수 있도록 구현

### DIFF
--- a/Projects/Modules/EasyLayoutModule/Demo/Sources/ViewController.swift
+++ b/Projects/Modules/EasyLayoutModule/Demo/Sources/ViewController.swift
@@ -47,7 +47,7 @@ final class EasyLayoutDemoViewController: UIViewController {
         view.addSubview(thirdView)
         
         firstView.ezl.makeConstraint {
-            $0.top(to: view.safeAreaLayoutGuide.ezl.top)
+            $0.top(to: view.safeAreaLayoutGuide)
                 .horizontal(to: view)
                 .height(200)
         }

--- a/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
+++ b/Projects/Modules/EasyLayoutModule/Sources/EasyConstraint.swift
@@ -38,12 +38,22 @@ public struct EasyConstraint {
     }
     
     @discardableResult
+    public func top(to view: Anchorable, offset: CGFloat = 0) -> Self {
+        top(to: view.ezl.top, offset: offset)
+    }
+    
+    @discardableResult
     public func bottom(to anchor: YAnchor, offset: CGFloat = 0) -> Self {
         baseView.bottomAnchor.constraint(
             equalTo: anchor.standard,
             constant: offset
         ).isActive = true
         return self
+    }
+    
+    @discardableResult
+    public func bottom(to view: Anchorable, offset: CGFloat = 0) -> Self {
+        bottom(to: view.ezl.bottom, offset: offset)
     }
     
     @discardableResult
@@ -56,12 +66,22 @@ public struct EasyConstraint {
     }
     
     @discardableResult
+    public func leading(to view: Anchorable, offset: CGFloat = 0) -> Self {
+        leading(to: view.ezl.leading, offset: offset)
+    }
+    
+    @discardableResult
     public func trailing(to anchor: XAnchor, offset: CGFloat = 0) -> Self {
         baseView.trailingAnchor.constraint(
             equalTo: anchor.standard,
             constant: offset
         ).isActive = true
         return self
+    }
+    
+    @discardableResult
+    public func trailing(to view: Anchorable, offset: CGFloat = 0) -> Self {
+        trailing(to: view.ezl.trailing, offset: offset)
     }
     
     @discardableResult


### PR DESCRIPTION
## 💡 요약 및 이슈 

### Anchorable 타입을 파라미터로 받을 수 있도록 구현

Resolves: #75

## 📃 작업내용

```swift
firstView.ezl.makeConstraint {
    $0.top(to: view.safeAreaLayoutGuide.ezl.top)
        .horizontal(to: view)
        .height(200)
}
```
만약 위와 같이 firstView의 top을 상대뷰의 top에 연결할 경우

```swift
firstView.ezl.makeConstraint {
    $0.top(to: view.safeAreaLayoutGuide)
        .horizontal(to: view)
        .height(200)
}
```
위와 처럼 `ezl.top`를 생략할 수 있도록 `Anchorable` 타입을 파라미터로 받을 수 있는 인터페이스 구현

## 🙋‍♂️ 리뷰노트

- 없습니다.

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
