### PR TITLE
task 플레이어 컨트롤 뷰 자동 닫힘 기능 구현

### DIFF
--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
@@ -129,6 +129,7 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
         
         output.isShowedInfoView
             .dropFirst()
+            .removeDuplicates()
             .sink { [weak self] flag in
                 guard let self else { return }
                 self.infoViewConstraintAnimation(flag)

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
@@ -120,6 +120,7 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
         
         output.isShowedPlayerControl
             .dropFirst()
+            .removeDuplicates()
             .sink { [weak self] flag in
                 guard let self else { return }
                 self.playerView.playerControlViewAlphaAnimalation(flag)

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 
 import BaseFeatureInterface
 
@@ -12,6 +13,7 @@ public final class LiveStreamViewModel: ViewModel {
         let playerStateDidChange: AnyPublisher<Bool?, Never>
         let playerGestureDidTap: AnyPublisher<Void?, Never>
         let playButtonDidTap: AnyPublisher<Void?, Never>
+        let autoDissmissDidRegister: PassthroughSubject<Void, Never> = .init()
     }
     
     public struct Output {
@@ -59,7 +61,13 @@ public final class LiveStreamViewModel: ViewModel {
         input.playerGestureDidTap
             .compactMap { $0 }
             .sink { _ in
-                output.isShowedPlayerControl.send(!output.isShowedPlayerControl.value)
+                let nextValue1 = !output.isShowedPlayerControl.value
+                output.isShowedPlayerControl.send(nextValue1)
+                
+                if nextValue1 {
+                    input.autoDissmissDidRegister.send()
+                }
+                
                 if output.isExpanded.value {
                     output.isShowedInfoView.send(false)
                 } else {
@@ -72,6 +80,13 @@ public final class LiveStreamViewModel: ViewModel {
             .compactMap { $0 }
             .sink { _ in
                 output.isPlaying.send(!output.isPlaying.value)
+            }
+            .store(in: &subscription)
+        
+        input.autoDissmissDidRegister
+            .debounce(for: .seconds(3), scheduler: DispatchQueue.main)
+            .sink { _ in
+                output.isShowedPlayerControl.send(false)
             }
             .store(in: &subscription)
         

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
@@ -47,6 +47,7 @@ public final class LiveStreamViewModel: ViewModel {
             .compactMap { $0 }
             .map{ Double($0) }
             .sink {
+                input.autoDissmissDidRegister.send()
                 output.time.send($0)
             }
             .store(in: &subscription)
@@ -79,6 +80,7 @@ public final class LiveStreamViewModel: ViewModel {
         input.playButtonDidTap
             .compactMap { $0 }
             .sink { _ in
+                input.autoDissmissDidRegister.send()
                 output.isPlaying.send(!output.isPlaying.value)
             }
             .store(in: &subscription)
@@ -87,6 +89,7 @@ public final class LiveStreamViewModel: ViewModel {
             .debounce(for: .seconds(3), scheduler: DispatchQueue.main)
             .sink { _ in
                 output.isShowedPlayerControl.send(false)
+                output.isShowedInfoView.send(false)
             }
             .store(in: &subscription)
         


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 플레이어 컨트롤 뷰 자동 닫힘 기능 구현

- Resolves: #150 

## 📃 작업내용

https://github.com/user-attachments/assets/2bcf7439-89c1-4918-856b-a4ade3a925e4

<img width="899" alt="스크린샷 2024-11-23 오후 4 33 08" src="https://github.com/user-attachments/assets/c7d76e3e-223a-4f7e-a951-977d185d2103">

### debounce 연산자를 이용한 이벤트 핕터링

3초 동안 동일한 이벤트가 들어왔을 때 타이머가 계속 갱신되어 가장 최신 것만 하나만 받게 만듭니다.
마치 텍스트 필드의 변화를 계속 방출하지말고 끝날 때 하나만 받는 이벤트와 같다고 생각합니다.


## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
