### PR TITLE
task #148 #161 앱그룹으로 소통하기

### DIFF
--- a/Projects/App/BroadcastExtension.entitlements
+++ b/Projects/App/BroadcastExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.kr.codesquad.boostcamp9.Shook</string>
+	</array>
+</dict>
+</plist>

--- a/Projects/App/BroadcastUploadExtension/Sources/SampleHandler.swift
+++ b/Projects/App/BroadcastUploadExtension/Sources/SampleHandler.swift
@@ -1,6 +1,18 @@
 import ReplayKit
 
 class SampleHandler: RPBroadcastSampleHandler {
-    override func broadcastStarted(withSetupInfo setupInfo: [String : NSObject]?) {
+    private let sharedDefaults = UserDefaults(suiteName: "group.kr.codesquad.boostcamp9.Shook")!
+    private let isStreamingKey = "isStreaming"
+    
+    override func broadcastStarted(withSetupInfo setupInfo: [String: NSObject]?) {
+        self.sharedDefaults.set(true, forKey: self.isStreamingKey)
+        
+    }
+    
+    override func broadcastFinished() {
+        sharedDefaults.set(false, forKey: isStreamingKey)
+    }
+    
+    override func processSampleBuffer(_ sampleBuffer: CMSampleBuffer, with sampleBufferType: RPSampleBufferType) {
     }
 }

--- a/Projects/App/Shook.entitlements
+++ b/Projects/App/Shook.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.kr.codesquad.boostcamp9.Shook</string>
+	</array>
+</dict>
+</plist>

--- a/Projects/Features/MainFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/MainFeature/Demo/Sources/AppDelegate.swift
@@ -12,15 +12,12 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
-    
-        let broadcastPicker = RPSystemBroadcastPickerView(frame: .init(x: UIScreen.main.bounds.width / 4, y: UIScreen.main.bounds.height / 3, width: 200, height: 60))
         
-        broadcastPicker.preferredExtension = "kr.codesquad.boostcamp9.Shook.BroadcastUploadExtension"
-        let viewController = UIViewController()
-                
-        viewController.view.addSubview(broadcastPicker)
-        viewController.view.backgroundColor = .white
-        window?.rootViewController = viewController
+        let fetcher = MockFetcher()
+        let viewModel = BroadcastCollectionViewModel(fetcher: fetcher)
+        let viewController = BroadcastCollectionViewController(viewModel: viewModel)
+        let navigationController = UINavigationController(rootViewController: viewController)
+        window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
         
         return true

--- a/Projects/Features/MainFeature/Project.swift
+++ b/Projects/Features/MainFeature/Project.swift
@@ -6,7 +6,6 @@ import EnvironmentPlugin
 let project = Project.module(
     name: ModulePaths.Feature.MainFeature.rawValue,
     targets: [
-      //  .broadcastExtension,
         .implements(module: .feature(.MainFeature), dependencies: [
             .feature(target: .BaseFeature)
         ]),

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
@@ -36,13 +36,16 @@ public class BroadcastCollectionViewModel: ViewModel {
     
     public struct Output {
         let items: PassthroughSubject<[Item], Never> = .init()
-        let isActive: CurrentValueSubject<Bool, Never> = CurrentValueSubject(false)
+        let streamingStartButtonIsActive: PassthroughSubject<Bool, Never> = .init()
         let errorMessage: PassthroughSubject<String?, Never> = .init()
     }
     
     private let output = Output()
     private var cancellables = Set<AnyCancellable>()
     private var fetcher: Fetcher
+    let sharedDefaults = UserDefaults(suiteName: "group.kr.codesquad.boostcamp9.Shook")!
+    let isStreamingKey = "isStreaming"
+    let extensionBundleID = "kr.codesquad.boostcamp9.Shook.BroadcastUploadExtension"
     
     public init(fetcher: Fetcher) {
         self.fetcher = fetcher
@@ -59,7 +62,7 @@ public class BroadcastCollectionViewModel: ViewModel {
             .sink { [weak self] name in
                 guard let self else { return }
                 let validness = valid(name)
-                self.output.isActive.send(validness.isValid)
+                self.output.streamingStartButtonIsActive.send(validness.isValid)
                 self.output.errorMessage.send(validness.errorMessage)
             }
             .store(in: &cancellables)

--- a/Projects/Features/MainFeature/Sources/BroadcastUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastUIViewController.swift
@@ -1,4 +1,5 @@
 import Combine
+import ReplayKit
 import UIKit
 
 import BaseFeature
@@ -6,15 +7,38 @@ import BaseFeatureInterface
 import DesignSystem
 
 public final class BroadcastUIViewController: BaseViewController<BroadcastCollectionViewModel> {
+    deinit {
+        viewModel.sharedDefaults.removeObserver(self, forKeyPath: viewModel.isStreamingKey)
+    }
+    
     private let broadcastStatusStackView = UIStackView()
     private let broadcastStatusImageView = UIImageView()
     private let broadcastStateText = UILabel()
     private let endBroadcastButton = UIButton()
     
+    private var broadcastPicker = RPSystemBroadcastPickerView()
+    
+    public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        if keyPath == viewModel.isStreamingKey {
+            if let newValue = change?[.newKey] as? Bool, !newValue {
+                didFinishBroadCast()
+            }
+        } else {
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+        }
+    }
+
     public override func setupViews() {
+        broadcastPicker.frame = CGRect(x: 0, y: 0, width: 0, height: 0)
+        broadcastPicker.preferredExtension = viewModel.extensionBundleID
+        
+        endBroadcastButton.addSubview(broadcastPicker)
+        
+        viewModel.sharedDefaults.addObserver(self, forKeyPath: viewModel.isStreamingKey, options: [.initial, .new], context: nil)
+        
         broadcastStatusStackView.addArrangedSubview(broadcastStatusImageView)
         broadcastStatusStackView.addArrangedSubview(broadcastStateText)
-
+        
         view.addSubview(broadcastStatusStackView)
         view.addSubview(endBroadcastButton)
     }
@@ -53,6 +77,12 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
                 .bottom(to: view.safeAreaLayoutGuide, offset: -23)
                 .horizontal(to: view, padding: 20)
         }
+        
+        broadcastPicker.ezl.makeConstraint {
+            $0.center(to: endBroadcastButton)
+                .width(endBroadcastButton.frame.width)
+                .height(endBroadcastButton.frame.height)
+        }
     }
     
     public override func setupActions() {
@@ -61,6 +91,11 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
     
     @objc
     private func didTapEndButton() {
+        guard let broadcastPickerButton = broadcastPicker.subviews.first(where: { $0 is UIButton }) as? UIButton else { return }
+        broadcastPickerButton.sendActions(for: .touchUpInside)
+    }
+    
+    private func didFinishBroadCast() {
         let newBroadcastCollectionViewController = BroadcastCollectionViewController(viewModel: viewModel)
         let navigationViewController = UINavigationController(rootViewController: newBroadcastCollectionViewController)
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,

--- a/Projects/Features/MainFeature/Sources/SettingTableViewCell.swift
+++ b/Projects/Features/MainFeature/Sources/SettingTableViewCell.swift
@@ -22,7 +22,8 @@ final class SettingTableViewCell: BaseTableViewCell {
         
     override func setupViews() {
         inputTextView.delegate = self
-        
+        inputTextView.returnKeyType = .done
+
         errorMessageLabel.isHidden = true
         inputTextView.addSubview(placeholderLabel)
         
@@ -102,5 +103,11 @@ extension SettingTableViewCell: UITextViewDelegate {
         guard let tableView = self.superview as? UITableView else { return }
         tableView.beginUpdates()
         tableView.endUpdates()
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        guard text == "\n" else { return true }
+        textView.resignFirstResponder()
+        return false
     }
 }

--- a/Projects/Features/MainFeature/Sources/SettingUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/SettingUIViewController.swift
@@ -1,4 +1,5 @@
 import Combine
+import ReplayKit
 import UIKit
 
 import BaseFeature
@@ -6,20 +7,35 @@ import DesignSystem
 import EasyLayoutModule
 
 public final class SettingUIViewController: BaseViewController<BroadcastCollectionViewModel> {
+    deinit {
+        viewModel.sharedDefaults.removeObserver(self, forKeyPath: viewModel.isStreamingKey)
+    }
     private let settingTableView = UITableView()
     private let closeBarButton = UIBarButtonItem()
     private let startStreamingButton = UIButton()
-    private let streamingNameCell = SettingTableViewCell(style: .default, reuseIdentifier: nil)
     private let streamingDescriptionCell = SettingTableViewCell(style: .default, reuseIdentifier: nil)
-    
+    private let streamingNameCell = SettingTableViewCell(style: .default, reuseIdentifier: nil)
     private let placeholderStringOfCells = ["어떤 방송인지 알려주세요!", "방송 내용을 알려주세요!"]
+    
+    private var broadcastPicker = RPSystemBroadcastPickerView()
+    
     private let viewModelInput = BroadcastCollectionViewModel.Input()
     private var cancellables = Set<AnyCancellable>()
+    
+    public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        if keyPath == viewModel.isStreamingKey {
+            if let newValue = change?[.newKey] as? Bool, newValue == true {
+                didStartBroadCast()
+            }
+        } else {
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+        }
+    }
     
     public override func setupBind() {
         let output = viewModel.transform(input: viewModelInput)
         
-        output.isActive
+        output.streamingStartButtonIsActive
             .sink { [weak self] isActive in
                 guard let self else { return }
                 self.startStreamingButton.isEnabled = isActive
@@ -38,6 +54,9 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
     }
     
     public override func setupViews() {
+        viewModel.sharedDefaults.addObserver(self, forKeyPath: viewModel.isStreamingKey, options: [.initial, .new], context: nil)
+        viewModel.sharedDefaults.set(false, forKey: viewModel.isStreamingKey)
+        
         closeBarButton.image = UIImage(systemName: "xmark")
         
         navigationItem.title = "방송설정"
@@ -49,7 +68,11 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
         settingTableView.rowHeight = UITableView.automaticDimension
         settingTableView.estimatedRowHeight = 100
         
+        broadcastPicker.frame = CGRect(x: 0, y: 0, width: 0, height: 0)
+        broadcastPicker.preferredExtension = viewModel.extensionBundleID
+
         startStreamingButton.isEnabled = false
+        startStreamingButton.addSubview(broadcastPicker)
         
         view.addSubview(settingTableView)
         view.addSubview(startStreamingButton)
@@ -57,7 +80,7 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
     
     public override func setupStyles() {
         view.backgroundColor = .black
-
+        
         closeBarButton.style = .plain
                 
         navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.white]
@@ -84,6 +107,12 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
                 .bottom(to: view.safeAreaLayoutGuide, offset: -23)
                 .horizontal(to: view, padding: 20)
         }
+        
+        broadcastPicker.ezl.makeConstraint {
+            $0.center(to: startStreamingButton)
+                .width(startStreamingButton.frame.width)
+                .height(startStreamingButton.frame.height)
+        }
     }
     
     public override func setupActions() {
@@ -100,12 +129,17 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
     
     @objc
     private func didTapSettingButton() {
-        let newBroadcastUIViewController = BroadcastUIViewController(viewModel: viewModel)
+        guard let broadcastPickerButton = broadcastPicker.subviews.first(where: { $0 is UIButton }) as? UIButton else { return }
+        broadcastPickerButton.sendActions(for: .touchUpInside)
+    }
+    
+    private func didStartBroadCast() {
+        let newBroadcastCollectionViewController = BroadcastUIViewController(viewModel: viewModel)
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return }
+              let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return }
         
-        UIView.transition(with: window, duration: 0.2, options: .transitionCrossDissolve) {
-            window.rootViewController = newBroadcastUIViewController
+        UIView.transition(with: window, duration: 0, options: .transitionCrossDissolve) {
+            window.rootViewController = newBroadcastCollectionViewController
         }
     }
 }

--- a/Projects/Features/MainFeature/Sources/SettingUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/SettingUIViewController.swift
@@ -122,11 +122,13 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
         closeBarButton.action = #selector(didTapRightBarButton)
     }
     
+    /// X 모양 버튼이 눌렸을 때 호출되는 메서드
     @objc
     private func didTapRightBarButton() {
         dismiss(animated: true, completion: nil)
     }
     
+    /// 방송 시작 버튼이 눌렸을 때 호출되는 메서드
     @objc
     private func didTapSettingButton() {
         guard let broadcastPickerButton = broadcastPicker.subviews.first(where: { $0 is UIButton }) as? UIButton else { return }
@@ -169,6 +171,6 @@ extension SettingUIViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
+        UITableView.automaticDimension
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/Extensions/Target+Extension.swift
+++ b/Tuist/ProjectDescriptionHelpers/Extensions/Target+Extension.swift
@@ -17,7 +17,9 @@ extension Target {
         infoPlist: .projectDefault,
         sources: .sources,
         resources: .resources,
-        entitlements: .dictionary(["com.apple.security.application-groups" : "group.kr.codesquad.boostcamp9.Shook"]),
+        entitlements: .dictionary(
+            ["com.apple.security.application-groups": .array([.string("group.kr.codesquad.boostcamp9.Shook")])]
+        ),
         scripts: generationEnvironment.scripts,
         dependencies: [
             .domain(target: .BaseDomain),
@@ -57,6 +59,9 @@ extension Target {
             ]
         ]),
         sources: "BroadcastUploadExtension/Sources/**",
+        entitlements: .dictionary(
+            ["com.apple.security.application-groups": .array([.string("group.kr.codesquad.boostcamp9.Shook")])]
+        ),
         dependencies: [
             .sdk(name: "ReplayKit", type: .framework, status: .required)
         ]

--- a/Tuist/ProjectDescriptionHelpers/Extensions/Target+Extension.swift
+++ b/Tuist/ProjectDescriptionHelpers/Extensions/Target+Extension.swift
@@ -17,6 +17,7 @@ extension Target {
         infoPlist: .projectDefault,
         sources: .sources,
         resources: .resources,
+        entitlements: .dictionary(["com.apple.security.application-groups" : "group.kr.codesquad.boostcamp9.Shook"]),
         scripts: generationEnvironment.scripts,
         dependencies: [
             .domain(target: .BaseDomain),


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 앱그룹을 사용해 extension에서 방송 시작,종료를 확인 후 뷰를 변경해줬습니다

- Resolves: #148, #161

## 📃 작업내용

- 앱그룹 추가
- 방송 시작, 종료시 UserDefaults 값변경
- 뷰컨트롤러에서 옵저버로 감시

## 🙋‍♂️ 리뷰노트

### 익스텐션과 소통하기
NotificatonCenter는 익스텐션에서 기본으로 사용할 수 없다고 합니다.
따라서 사용가능한 두가지 선택지가 있었습니다
1. Darwin Notifications
2. UserDefaults

처음에는 두가지 방법 모두 되지 않아 어려움을 겪었으나, 확인해보니 tuist쪽에서 앱그룹을 잘못 넣어줬다는 것을 파악했습니다.
1번의 경우에는 싱글톤으로 따로 매니저같은 객체를 구현해줘야했기에 2번을 선택했습니다.

추가로 tuist에서 처음에 딕셔너리로 키: 문자열 형태로 앱그룹을 추가해줬으나 정상적으로 작동되지 않는 문제를 발견했습니다.
확인해보니, 키: 배열(문자열) 형태로 넣어줘야한다고 합니다 😂

키: 문자열 형태로하면 generate했을 때 앱그룹 자체는 추가되나 설정해둔 value의 앱그룹이 체크가 되지 않습니다ㅠ

### 커밋관련
방송 시작과 방송 종료 이슈가 나눠져있는 것을 확인하지 못해 커밋을 나누지 못했습니다 😂
다음부터는 조금 더 신경쓰도록하겠습니다!

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
