### PR TITLE
task #160 화면전환시 발생한 오류 수정

### DIFF
--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
@@ -268,11 +268,24 @@ extension BroadcastCollectionViewController {
     }
     
     private func showBroadcastUIView() {
+        navigationController?.setNavigationBarHidden(true, animated: false)
         let broadcastViewController = BroadcastUIViewController(viewModel: viewModel)
-        present(broadcastViewController, animated: false)
+        self.addChild(broadcastViewController)
+        self.view.addSubview(broadcastViewController.view)
+        broadcastViewController.view.frame = self.view.bounds
+        broadcastViewController.didMove(toParent: self)
     }
     
     private func dismissBroadcastUIView() {
+        guard let broadcastViewController = children.first(where: { $0 is BroadcastUIViewController }) else { return }
+        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut], animations: {
+            broadcastViewController.view.alpha = 0 }, completion: { _ in
+                broadcastViewController.willMove(toParent: nil)
+                broadcastViewController.view.removeFromSuperview()
+                broadcastViewController.removeFromParent()
+            }
+        )
+        navigationController?.setNavigationBarHidden(false, animated: false)
         input.fetch.send()
     }
 }

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
@@ -98,6 +98,7 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
         refreshControl.addAction(UIAction { [weak self] _ in
             self?.input.fetch.send()
         }, for: .valueChanged)
+        
         rightBarButton.target = self
         rightBarButton.action = #selector(didTapRightBarButton)
     }
@@ -110,6 +111,19 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
                 self?.applySnapshot(with: items)
             }
             .store(in: &cancellables)
+        
+        output.showBroadcastUIView
+            .sink { [weak self] _ in
+                self?.showBroadcastView()
+            }
+            .store(in: &cancellables)
+        
+        output.dismissBroadcastUIView
+            .sink { [weak self] _ in
+                self?.dismissBroadcastView()
+                self?.input.fetch.send()
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -119,7 +133,7 @@ extension BroadcastCollectionViewController: UICollectionViewDelegate {
         guard let viewController = factory?.make() else { return }
         viewController.modalPresentationStyle = .overCurrentContext
         viewController.transitioningDelegate = transitioning
-        present(viewController, animated: true, completion: nil)        
+        present(viewController, animated: true)
     }
 }
 
@@ -248,10 +262,30 @@ extension BroadcastCollectionViewController {
 
 // MARK: - CollectionView Methods
 extension BroadcastCollectionViewController {
-    @objc
-    private func didTapRightBarButton() {
+    @objc private func didTapRightBarButton() {
         let settingUIViewController = SettingUIViewController(viewModel: viewModel)
         let settingNavigationController = UINavigationController(rootViewController: settingUIViewController)
         navigationController?.present(settingNavigationController, animated: true)
+    }
+    
+    private func showBroadcastView() {
+        navigationController?.setNavigationBarHidden(true, animated: false)
+        let broadcastViewController = BroadcastUIViewController(viewModel: viewModel)
+        self.addChild(broadcastViewController)
+        self.view.addSubview(broadcastViewController.view)
+        broadcastViewController.view.frame = self.view.bounds
+        broadcastViewController.didMove(toParent: self)
+    }
+    
+    private func dismissBroadcastView() {
+        guard let broadcastViewController = children.first(where: { $0 is BroadcastUIViewController }) else { return }
+        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut], animations: {
+            broadcastViewController.view.alpha = 0 }, completion: { _ in
+                broadcastViewController.willMove(toParent: nil)
+                broadcastViewController.view.removeFromSuperview()
+                broadcastViewController.removeFromParent()
+            }
+        )
+        navigationController?.setNavigationBarHidden(false, animated: false)
     }
 }

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
@@ -114,14 +114,13 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
         
         output.showBroadcastUIView
             .sink { [weak self] _ in
-                self?.showBroadcastView()
+                self?.showBroadcastUIView()
             }
             .store(in: &cancellables)
         
         output.dismissBroadcastUIView
             .sink { [weak self] _ in
-                self?.dismissBroadcastView()
-                self?.input.fetch.send()
+                self?.dismissBroadcastUIView()
             }
             .store(in: &cancellables)
     }
@@ -268,24 +267,12 @@ extension BroadcastCollectionViewController {
         navigationController?.present(settingNavigationController, animated: true)
     }
     
-    private func showBroadcastView() {
-        navigationController?.setNavigationBarHidden(true, animated: false)
+    private func showBroadcastUIView() {
         let broadcastViewController = BroadcastUIViewController(viewModel: viewModel)
-        self.addChild(broadcastViewController)
-        self.view.addSubview(broadcastViewController.view)
-        broadcastViewController.view.frame = self.view.bounds
-        broadcastViewController.didMove(toParent: self)
+        present(broadcastViewController, animated: false)
     }
     
-    private func dismissBroadcastView() {
-        guard let broadcastViewController = children.first(where: { $0 is BroadcastUIViewController }) else { return }
-        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut], animations: {
-            broadcastViewController.view.alpha = 0 }, completion: { _ in
-                broadcastViewController.willMove(toParent: nil)
-                broadcastViewController.view.removeFromSuperview()
-                broadcastViewController.removeFromParent()
-            }
-        )
-        navigationController?.setNavigationBarHidden(false, animated: false)
+    private func dismissBroadcastUIView() {
+        input.fetch.send()
     }
 }

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
@@ -19,7 +19,7 @@ public class BroadcastCollectionViewModel: ViewModel {
     public struct Input {
         let fetch: PassthroughSubject<Void, Never> = .init()
         let didWriteStreamingName: PassthroughSubject<String, Never> = .init()
-        let didTapStreamingButton: PassthroughSubject<Void, Never> = .init()
+        let didTapBroadcastButton: PassthroughSubject<Void, Never> = .init()
         let didTapEndStreamingButton: PassthroughSubject<Void, Never> = .init()
     }
     
@@ -58,7 +58,7 @@ public class BroadcastCollectionViewModel: ViewModel {
             }
             .store(in: &cancellables)
         
-        input.didTapStreamingButton
+        input.didTapBroadcastButton
             .sink { [weak self] _ in
                 self?.output.showBroadcastUIView.send()
             }

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
@@ -19,12 +19,16 @@ public class BroadcastCollectionViewModel: ViewModel {
     public struct Input {
         let fetch: PassthroughSubject<Void, Never> = .init()
         let didWriteStreamingName: PassthroughSubject<String, Never> = .init()
+        let didTapStreamingButton: PassthroughSubject<Void, Never> = .init()
+        let didTapEndStreamingButton: PassthroughSubject<Void, Never> = .init()
     }
     
     public struct Output {
         let items: PassthroughSubject<[Channel], Never> = .init()
         let isActive: CurrentValueSubject<Bool, Never> = CurrentValueSubject(false)
         let errorMessage: PassthroughSubject<String?, Never> = .init()
+        let showBroadcastUIView: PassthroughSubject<Void, Never> = .init()
+        let dismissBroadcastUIView: PassthroughSubject<Void, Never> = .init()
     }
     
     private let output = Output()
@@ -48,6 +52,18 @@ public class BroadcastCollectionViewModel: ViewModel {
                 let validness = valid(name)
                 self.output.isActive.send(validness.isValid)
                 self.output.errorMessage.send(validness.errorMessage)
+            }
+            .store(in: &cancellables)
+        
+        input.didTapStreamingButton
+            .sink { [weak self] _ in
+                self?.output.showBroadcastUIView.send()
+            }
+            .store(in: &cancellables)
+        
+        input.didTapEndStreamingButton
+            .sink { [weak self] _ in
+                self?.output.dismissBroadcastUIView.send()
             }
             .store(in: &cancellables)
         

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
@@ -25,7 +25,7 @@ public class BroadcastCollectionViewModel: ViewModel {
     
     public struct Output {
         let items: PassthroughSubject<[Channel], Never> = .init()
-        let isActive: CurrentValueSubject<Bool, Never> = CurrentValueSubject(false)
+        let isActive: PassthroughSubject<Bool, Never> = .init()
         let errorMessage: PassthroughSubject<String?, Never> = .init()
         let showBroadcastUIView: PassthroughSubject<Void, Never> = .init()
         let dismissBroadcastUIView: PassthroughSubject<Void, Never> = .init()

--- a/Projects/Features/MainFeature/Sources/BroadcastUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastUIViewController.swift
@@ -19,7 +19,7 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
     private let viewModelInput = BroadcastCollectionViewModel.Input()
     
     public override func setupBind() {
-        let output = viewModel.transform(input: viewModelInput)
+        let _ = viewModel.transform(input: viewModelInput)
     }
     
     private var broadcastPicker = RPSystemBroadcastPickerView()
@@ -102,6 +102,7 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
     }
     
     private func didFinishBroadCast() {
+        dismiss(animated: false)
         viewModelInput.didTapEndStreamingButton.send()
     }
 }

--- a/Projects/Features/MainFeature/Sources/BroadcastUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastUIViewController.swift
@@ -11,6 +11,12 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
     private let broadcastStateText = UILabel()
     private let endBroadcastButton = UIButton()
     
+    private let viewModelInput = BroadcastCollectionViewModel.Input()
+    
+    public override func setupBind() {
+        let output = viewModel.transform(input: viewModelInput)
+    }
+    
     public override func setupViews() {
         broadcastStatusStackView.addArrangedSubview(broadcastStatusImageView)
         broadcastStatusStackView.addArrangedSubview(broadcastStateText)
@@ -61,13 +67,6 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
     
     @objc
     private func didTapEndButton() {
-        let newBroadcastCollectionViewController = BroadcastCollectionViewController(viewModel: viewModel)
-        let navigationViewController = UINavigationController(rootViewController: newBroadcastCollectionViewController)
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return }
-        
-        UIView.transition(with: window, duration: 0, options: .transitionCrossDissolve) {
-            window.rootViewController = navigationViewController
-        }
+        viewModelInput.didTapEndStreamingButton.send()
     }
 }

--- a/Projects/Features/MainFeature/Sources/SettingUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/SettingUIViewController.swift
@@ -91,7 +91,7 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         view.addGestureRecognizer(tapGesture)
         
-        startStreamingButton.addTarget(self, action: #selector(didTapSettingButton), for: .touchUpInside)
+        startStreamingButton.addTarget(self, action: #selector(didTapStreamingButton), for: .touchUpInside)
         
         closeBarButton.target = self
         closeBarButton.action = #selector(didTapRightBarButton)
@@ -103,14 +103,9 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
     }
     
     @objc
-    private func didTapSettingButton() {
-        let newBroadcastUIViewController = BroadcastUIViewController(viewModel: viewModel)
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return }
-        
-        UIView.transition(with: window, duration: 0.2, options: .transitionCrossDissolve) {
-            window.rootViewController = newBroadcastUIViewController
-        }
+    private func didTapStreamingButton() {
+        viewModelInput.didTapStreamingButton.send()
+        dismiss(animated: true)
     }
     
     @objc

--- a/Projects/Features/MainFeature/Sources/SettingUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/SettingUIViewController.swift
@@ -10,9 +10,10 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
     deinit {
         viewModel.sharedDefaults.removeObserver(self, forKeyPath: viewModel.isStreamingKey)
     }
+    
     private let settingTableView = UITableView()
     private let closeBarButton = UIBarButtonItem()
-    private let startStreamingButton = UIButton()
+    private let startBroadcastButton = UIButton()
     private let streamingDescriptionCell = SettingTableViewCell(style: .default, reuseIdentifier: nil)
     private let streamingNameCell = SettingTableViewCell(style: .default, reuseIdentifier: nil)
     private let placeholderStringOfCells = ["어떤 방송인지 알려주세요!", "방송 내용을 알려주세요!"]
@@ -38,8 +39,8 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
         output.streamingStartButtonIsActive
             .sink { [weak self] isActive in
                 guard let self else { return }
-                self.startStreamingButton.isEnabled = isActive
-                self.startStreamingButton.backgroundColor = isActive
+                self.startBroadcastButton.isEnabled = isActive
+                self.startBroadcastButton.backgroundColor = isActive
                     ? DesignSystemAsset.Color.mainGreen.color
                     : DesignSystemAsset.Color.gray.color
             }
@@ -71,11 +72,11 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
         broadcastPicker.frame = CGRect(x: 0, y: 0, width: 0, height: 0)
         broadcastPicker.preferredExtension = viewModel.extensionBundleID
 
-        startStreamingButton.isEnabled = false
-        startStreamingButton.addSubview(broadcastPicker)
+        startBroadcastButton.isEnabled = false
+        startBroadcastButton.addSubview(broadcastPicker)
         
         view.addSubview(settingTableView)
-        view.addSubview(startStreamingButton)
+        view.addSubview(startBroadcastButton)
     }
     
     public override func setupStyles() {
@@ -89,30 +90,30 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
         
         settingTableView.backgroundColor = .black
         
-        startStreamingButton.setTitle("방송시작", for: .normal)
-        startStreamingButton.layer.cornerRadius = 16
-        startStreamingButton.titleLabel?.font = .setFont(.body1(weight: .semiBold))
-        startStreamingButton.backgroundColor = DesignSystemAsset.Color.gray.color
-        startStreamingButton.setTitleColor(DesignSystemAsset.Color.mainBlack.color, for: .normal)
+        startBroadcastButton.setTitle("방송시작", for: .normal)
+        startBroadcastButton.layer.cornerRadius = 16
+        startBroadcastButton.titleLabel?.font = .setFont(.body1(weight: .semiBold))
+        startBroadcastButton.backgroundColor = DesignSystemAsset.Color.gray.color
+        startBroadcastButton.setTitleColor(DesignSystemAsset.Color.mainBlack.color, for: .normal)
     }
         
     public override func setupLayouts() {
         settingTableView.ezl.makeConstraint {
             $0.top(to: view.safeAreaLayoutGuide, offset: 21)
-                .bottom(to: startStreamingButton.ezl.top)
+                .bottom(to: startBroadcastButton.ezl.top)
                 .horizontal(to: view, padding: 20)
         }
         
-        startStreamingButton.ezl.makeConstraint {
+        startBroadcastButton.ezl.makeConstraint {
             $0.height(56)
                 .bottom(to: view.safeAreaLayoutGuide, offset: -23)
                 .horizontal(to: view, padding: 20)
         }
         
         broadcastPicker.ezl.makeConstraint {
-            $0.center(to: startStreamingButton)
-                .width(startStreamingButton.frame.width)
-                .height(startStreamingButton.frame.height)
+            $0.center(to: startBroadcastButton)
+                .width(startBroadcastButton.frame.width)
+                .height(startBroadcastButton.frame.height)
         }
     }
     
@@ -120,7 +121,7 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         view.addGestureRecognizer(tapGesture)
         
-        startStreamingButton.addTarget(self, action: #selector(didTapStreamingButton), for: .touchUpInside)
+        startBroadcastButton.addTarget(self, action: #selector(didTapStartBroadcastButton), for: .touchUpInside)
         
         closeBarButton.target = self
         closeBarButton.action = #selector(didTapRightBarButton)
@@ -129,18 +130,18 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
     /// X 모양 버튼이 눌렸을 때 호출되는 메서드
     @objc
     private func didTapRightBarButton() {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
     
     /// 방송 시작 버튼이 눌렸을 때 호출되는 메서드
     @objc
-    private func didTapSettingButton() {
+    private func didTapStartBroadcastButton() {
         guard let broadcastPickerButton = broadcastPicker.subviews.first(where: { $0 is UIButton }) as? UIButton else { return }
         broadcastPickerButton.sendActions(for: .touchUpInside)
     }
     
     private func didStartBroadCast() {
-        viewModelInput.didTapStreamingButton.send()
+        viewModelInput.didTapBroadcastButton.send()
         dismiss(animated: true)
     }
     
@@ -160,8 +161,8 @@ extension SettingUIViewController: UITableViewDelegate, UITableViewDataSource {
             streamingNameCell.configure(
                 label: "방송이름",
                 placeholder: placeholderStringOfCells[indexPath.row]
-            ) { inputValue in
-                self.viewModelInput.didWriteStreamingName.send(inputValue)
+            ) { [weak self] inputValue in
+                self?.viewModelInput.didWriteStreamingName.send(inputValue)
             }
             return streamingNameCell
         } else {


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 리스트 뷰와 세팅 뷰 전환 관련 생긴 오류를 수정했습니다.
- 먼저 올린 #159 이 머지되고 머지되어야 하는 브랜치입니다.

- Resolves: #160 

## 📃 작업내용

- 기존에 화면전환시 `factory`를 넣어주지 못하기 때문에 `PlayerView`로 전환을 못하는 오류가 있었습니다.
- 화면 전환을 부드럽게 하여 사용성을 높였습니다.

| 오류 화면 |
| -- |
| <image width="250" src="https://github.com/user-attachments/assets/abd6ff27-95ec-46b5-b15c-778a2bb60767"> |

- 뷰의 로직을 수정하여 해결하였습니다.

| 해결된 화면 |
| -- |
| <image width="250" src="https://github.com/user-attachments/assets/274ba140-a748-4356-9aee-c7ca24d984d3"> |

#### 기존의 로직

- `window`의 `rootViewController`를 계속 바꾸는 식으로 화면전환이 일어났습니다.
- @INYEKIM `windowScene`의 `window`의 `rootView`를 바꾸는 방식이 `controller`를 위에 최상단에 위치하는것보다 리소스를 훨씬 더 잡아먹을 것이라 생각드는데 어떻게 생각하시는지 궁금합니다!

```swift
    @objc
    private func didTapEndButton() {
        let newBroadcastCollectionViewController = BroadcastCollectionViewController(viewModel: viewModel)
        let navigationViewController = UINavigationController(rootViewController: newBroadcastCollectionViewController)
        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return }
        
        UIView.transition(with: window, duration: 0, options: .transitionCrossDissolve) {
            window.rootViewController = navigationViewController
        }
    }

    @objc
    private func didTapSettingButton() {
        let newBroadcastUIViewController = BroadcastUIViewController(viewModel: viewModel)
        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return }
        
        UIView.transition(with: window, duration: 0.2, options: .transitionCrossDissolve) {
            window.rootViewController = newBroadcastUIViewController
        }
    }
```

#### 수정된 로직

```swift
    private func showBroadcastView() {
        navigationController?.setNavigationBarHidden(true, animated: false)
        let broadcastViewController = BroadcastUIViewController(viewModel: viewModel)
        self.addChild(broadcastViewController)
        self.view.addSubview(broadcastViewController.view)
        broadcastViewController.view.frame = self.view.bounds
        broadcastViewController.didMove(toParent: self)
    }
    
    private func dismissBroadcastView() {
        guard let broadcastViewController = children.first(where: { $0 is BroadcastUIViewController }) else { return }
        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut], animations: {
            broadcastViewController.view.alpha = 0 }, completion: { _ in
                broadcastViewController.willMove(toParent: nil)
                broadcastViewController.view.removeFromSuperview()
                broadcastViewController.removeFromParent()
            }
        )
        navigationController?.setNavigationBarHidden(false, animated: false)
    }
```

- 또한 BroadcastUI가 사라졌을때 아래와 같이 fetch가 되게 했습니다.

```swift
        output.dismissBroadcastUIView
            .sink { [weak self] _ in
                self?.dismissBroadcastView()
                self?.input.fetch.send()
            }
            .store(in: &cancellables)
```

### 추가 사항
- 아래와 같이 채널을 한번 생성하고 isActive가 초기화가 되지 않아 그다음부터는 유효성 검사를 패스해버리는 오류가있었습니다.

| 오류 화면 |
| -- |
| <image width="250" src="https://github.com/user-attachments/assets/3e35609f-9793-47da-8efe-a2f4e192532e"> |

- 간단하게 `isActive`를 `PassthroughObject`로 변경하니 해결되었습니다.

| 해결 화면 |
| -- |
| <image width="250" src="https://github.com/user-attachments/assets/b2a3776e-5298-4302-9130-4491ea675cd5"> |

## 🙋‍♂️ 리뷰노트

- @INYEKIM 
- 버튼을 수정했습니다!
- 관련 로직을 수정했습니다!!

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
