### PR TITLE
task #206 방송중인 리스트가 없을 때 보여줄 화면 구현

### DIFF
--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionEmptyView.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionEmptyView.swift
@@ -1,0 +1,53 @@
+import UIKit
+
+import BaseFeature
+import DesignSystem
+
+final class BroadcastCollectionEmptyView: BaseView {
+    private let imageView = UIImageView()
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    
+    private lazy var textStackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+    private lazy var stackView = UIStackView(arrangedSubviews: [imageView, textStackView])
+    
+    override func setupViews() {
+        addSubview(stackView)
+        
+        imageView.image = DesignSystemAsset.Image.tv48.image
+        
+        titleLabel.text = "아직 라이브 방송이 없어요!"
+        
+        subtitleLabel.text = "잠시 후 다시 확인해 주세요!"
+    }
+    
+    override func setupStyles() {
+        titleLabel.textColor = .white
+        titleLabel.font = .setFont(.title())
+        
+        subtitleLabel.textColor = .gray
+        subtitleLabel.font = .setFont(.body2())
+        
+        textStackView.axis = .vertical
+        textStackView.spacing = 7
+        textStackView.alignment = .center
+        
+        stackView.axis = .vertical
+        stackView.spacing = 13
+        stackView.alignment = .center
+    }
+    
+    override func layoutSubviews() {
+        let imageSize = min(bounds.width * 0.25, bounds.height * 0.2)
+        
+        imageView.ezl.makeConstraint {
+            $0.size(with: imageSize)
+        }
+    }
+    
+    override func setupLayouts() {
+        stackView.ezl.makeConstraint {
+            $0.center(to: self)
+        }
+    }
+}

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
@@ -28,6 +28,8 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
     
     private let transitioning = CollectionViewCellTransitioning()
     
+    private let emptyView = BroadcastCollectionEmptyView()
+    
     var selectedThumbnailView: ThumbnailView? {
         guard let indexPath = collectionView.indexPathsForSelectedItems?.first else { return nil }
         let cell = collectionView.cellForItem(at: indexPath)
@@ -69,6 +71,9 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
         collectionView.register(SmallBroadcastCollectionViewCell.self, forCellWithReuseIdentifier: SmallBroadcastCollectionViewCell.identifier)
         collectionView.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "Header")
         
+        emptyView.isHidden = true
+        
+        view.addSubview(emptyView)
         view.addSubview(collectionView)
     }
     
@@ -90,6 +95,10 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
     
     public override func setupLayouts() {
         collectionView.ezl.makeConstraint {
+            $0.diagonal(to: view)
+        }
+        
+        emptyView.ezl.makeConstraint {
             $0.diagonal(to: view)
         }
     }
@@ -239,6 +248,14 @@ extension BroadcastCollectionViewController {
     }
     
     private func applySnapshot(with channels: [Channel]) {
+        if channels.isEmpty {
+            collectionView.isHidden = true
+            emptyView.isHidden = false
+        } else {
+            collectionView.isHidden = false
+            emptyView.isHidden = true
+        }
+        
         var snapshot = Snapshot()
         
         let bigSectionItems = Array(channels.prefix(3))


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 방송중인 화면이 없을때 검정색 화면만 뜨지 않도록 새로운 뷰를 추가했습니다

- Resolves: #206 

## 📃 작업내용

- empty뷰 구현
- 리스트가 없을 때 empty 뷰 보여주기

## 🙋‍♂️ 리뷰노트

viemodel과 연결하다가 발견한 이슈로 따로 브랜치를 나누지 않고 작업하고 있는 브랜치에서 진행했습니다. 참고부탁드립니다.

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
