### PR TITLE
task #199 채팅 서버와 소켓 연결

### DIFF
--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -55,7 +55,7 @@ extension SceneDelegate {
         let chatRepositoryImpl: any ChatRepository = ChatRepositoryImpl()
         let makeRoomUseCase: any MakeChatRoomUseCase = MakeChatRoomUseCaseImpl(repository: chatRepositoryImpl)
         let deleteRoomUseCase: any DeleteChatRoomUseCase = DeleteChatRoomUseCaseImpl(repository: chatRepositoryImpl)
-        let liveStreamFactoryImpl = LiveStreamViewControllerFractoryImpl(makeChatRoomUseCase: makeRoomUseCase, deleteChatRoomUseCase: deleteRoomUseCase)
+        let liveStreamFactoryImpl = LiveStreamViewControllerFractoryImpl()
         DIContainer.shared.register(LiveStreamViewControllerFactory.self, dependency: liveStreamFactoryImpl)
         
         let liveStationRepository = LiveStationRepositoryImpl()

--- a/Projects/Features/LiveStreamFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/LiveStreamFeature/Demo/Sources/AppDelegate.swift
@@ -11,10 +11,10 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
-        let viewController = UIViewController()
+        let viewModel = LiveStreamViewModel(channelID: "1234")
+        let viewController = LiveStreamViewController(viewModel: viewModel)
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()
         return true
     }
 }
-

--- a/Projects/Features/LiveStreamFeature/Interface/LiveStreamViewControllerFactory.swift
+++ b/Projects/Features/LiveStreamFeature/Interface/LiveStreamViewControllerFactory.swift
@@ -3,5 +3,5 @@ import UIKit
 import BaseFeatureInterface
 
 public protocol LiveStreamViewControllerFactory {
-    func make() -> UIViewController
+    func make(channelID: String) -> UIViewController
 }

--- a/Projects/Features/LiveStreamFeature/Project.swift
+++ b/Projects/Features/LiveStreamFeature/Project.swift
@@ -12,7 +12,6 @@ let project = Project.module(
             .feature(target: .LiveStreamFeature, type: .interface),
             .feature(target: .BaseFeature),
             .domain(target: .LiveStationDomain, type: .interface),
-            .domain(target: .ChattingDomain, type: .interface),
             .module(target: .ChatSoketModule)
         ]),
         .tests(module: .feature(.LiveStreamFeature), dependencies: [

--- a/Projects/Features/LiveStreamFeature/Sources/Chating/Views/ChatInputField.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Chating/Views/ChatInputField.swift
@@ -103,7 +103,7 @@ final class ChatInputField: BaseView {
         sendButton.addAction(
             UIAction { [weak self] _ in
                 guard let self else { return }
-                #warning("Chating User Name 추후 수정")
+                #warning("chatting User Name 추후 수정")
                 sendButtonDidTapPublisher = ChatInfo(
                     name: "홍길동",
                     message: inputField.text

--- a/Projects/Features/LiveStreamFeature/Sources/Chating/Views/ChatingCell.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Chating/Views/ChatingCell.swift
@@ -4,7 +4,7 @@ import BaseFeature
 import DesignSystem
 import EasyLayoutModule
 
-final class ChatingCell: BaseTableViewCell {    
+final class ChattingCell: BaseTableViewCell {    
     private let nameLabel = UILabel()
     private let detailLabel = UILabel()
     

--- a/Projects/Features/LiveStreamFeature/Sources/Chating/Views/ChatingListView.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Chating/Views/ChatingListView.swift
@@ -3,7 +3,7 @@ import UIKit
 import BaseFeature
 import EasyLayoutModule
 
-final class ChatingListView: BaseView {
+final class ChattingListView: BaseView {
     private let titleLabel = UILabel()
     private let chatListView = UITableView(frame: .zero, style: .plain)
     private let chatEmptyView = ChatEmptyView()
@@ -12,9 +12,9 @@ final class ChatingListView: BaseView {
         tableView: chatListView
     ) { tableView, indexPath, chatInfo in
         let cell = tableView.dequeueReusableCell(
-            withIdentifier: ChatingCell.identifier,
+            withIdentifier: ChattingCell.identifier,
             for: indexPath
-        ) as? ChatingCell ?? ChatingCell()
+        ) as? ChattingCell ?? ChattingCell()
         cell.configure(chat: chatInfo)
         return cell
     }
@@ -25,7 +25,7 @@ final class ChatingListView: BaseView {
         
         titleLabel.text = "실시간 채팅"
         
-        chatListView.register(ChatingCell.self, forCellReuseIdentifier: ChatingCell.identifier)
+        chatListView.register(ChattingCell.self, forCellReuseIdentifier: ChattingCell.identifier)
         chatListView.backgroundView = chatEmptyView
     }
     
@@ -60,7 +60,7 @@ final class ChatingListView: BaseView {
     }
 }
 
-extension ChatingListView {
+extension ChattingListView {
     func updateList(_ chatList: [ChatInfo]) {
         chatEmptyView.isHidden = !chatList.isEmpty
         

--- a/Projects/Features/LiveStreamFeature/Sources/Factory/LiveStreamViewControllerFractoryImpl.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Factory/LiveStreamViewControllerFractoryImpl.swift
@@ -6,6 +6,8 @@ import LiveStreamFeatureInterface
 
 public struct LiveStreamViewControllerFractoryImpl: LiveStreamViewControllerFactory {
     
+    public init() {}
+    
     public func make(channelID: String) -> UIViewController {
         let viewModel = LiveStreamViewModel(channelID: channelID)
         return LiveStreamViewController(viewModel: viewModel)

--- a/Projects/Features/LiveStreamFeature/Sources/Factory/LiveStreamViewControllerFractoryImpl.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Factory/LiveStreamViewControllerFractoryImpl.swift
@@ -14,8 +14,8 @@ public struct LiveStreamViewControllerFractoryImpl: LiveStreamViewControllerFact
         self.deleteChatRoomUseCase = deleteChatRoomUseCase
     }
     
-    public func make() -> UIViewController {
-        let viewModel = LiveStreamViewModel(makeChatRoomUseCase: makeChatRoomUseCase, deleteChatRoomUseCase: deleteChatRoomUseCase)
+    public func make(channelID: String) -> UIViewController {
+        let viewModel = LiveStreamViewModel(channelID: channelID, makeChatRoomUseCase: makeChatRoomUseCase, deleteChatRoomUseCase: deleteChatRoomUseCase)
         return LiveStreamViewController(viewModel: viewModel)
     }
 }

--- a/Projects/Features/LiveStreamFeature/Sources/Factory/LiveStreamViewControllerFractoryImpl.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Factory/LiveStreamViewControllerFractoryImpl.swift
@@ -6,16 +6,8 @@ import LiveStreamFeatureInterface
 
 public struct LiveStreamViewControllerFractoryImpl: LiveStreamViewControllerFactory {
     
-    private let makeChatRoomUseCase: any MakeChatRoomUseCase
-    private let deleteChatRoomUseCase: any DeleteChatRoomUseCase
-    
-    public init(makeChatRoomUseCase: any MakeChatRoomUseCase, deleteChatRoomUseCase: DeleteChatRoomUseCase) {
-        self.makeChatRoomUseCase = makeChatRoomUseCase
-        self.deleteChatRoomUseCase = deleteChatRoomUseCase
-    }
-    
     public func make(channelID: String) -> UIViewController {
-        let viewModel = LiveStreamViewModel(channelID: channelID, makeChatRoomUseCase: makeChatRoomUseCase, deleteChatRoomUseCase: deleteChatRoomUseCase)
+        let viewModel = LiveStreamViewModel(channelID: channelID)
         return LiveStreamViewController(viewModel: viewModel)
     }
 }

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
@@ -17,6 +17,8 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
     private var foldedConstraint: NSLayoutConstraint?
     private var subscription = Set<AnyCancellable>()
     
+    private let viewDidLoadPublisher = PassthroughSubject<Void, Never>()
+    
     private lazy var input = LiveStreamViewModel.Input(
         expandButtonDidTap: playerView.playerControlView.expandButtonDidTap.eraseToAnyPublisher(),
         sliderValueDidChange: playerView.playerControlView.timeControlView.valueDidChanged.eraseToAnyPublisher(),
@@ -24,7 +26,8 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
         playerGestureDidTap: playerView.playerGestureDidTap.eraseToAnyPublisher(),
         playButtonDidTap: playerView.playerControlView.playButtonDidTap.eraseToAnyPublisher(),
         dismissButtonDidTap: playerView.playerControlView.dismissButtonDidTap.eraseToAnyPublisher(),
-        chattingSendButtonDidTap: chatInputField.sendButtonDidTap.eraseToAnyPublisher()
+        chattingSendButtonDidTap: chatInputField.sendButtonDidTap.eraseToAnyPublisher(),
+        viewDidLoad: viewDidLoadPublisher.eraseToAnyPublisher()
     )
     
     private lazy var output = viewModel.transform(input: input)

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
@@ -6,7 +6,7 @@ import DesignSystem
 import EasyLayoutModule
 
 public final class LiveStreamViewController: BaseViewController<LiveStreamViewModel> {
-    private let chatingList = ChatingListView()
+    private let chattingList = ChattingListView()
     private let chatInputField = ChatInputField()
     private let playerView: ShookPlayerView = ShookPlayerView(with: URL(string: "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8")!)
     private let infoView: LiveStreamInfoView = LiveStreamInfoView()
@@ -24,7 +24,7 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
         playerGestureDidTap: playerView.playerGestureDidTap.eraseToAnyPublisher(),
         playButtonDidTap: playerView.playerControlView.playButtonDidTap.eraseToAnyPublisher(),
         dismissButtonDidTap: playerView.playerControlView.dismissButtonDidTap.eraseToAnyPublisher(),
-        chatingSendButtonDidTap: chatInputField.sendButtonDidTap.eraseToAnyPublisher()
+        chattingSendButtonDidTap: chatInputField.sendButtonDidTap.eraseToAnyPublisher()
     )
     
     private lazy var output = viewModel.transform(input: input)
@@ -40,7 +40,7 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
     public override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         
-        chatingList.isHidden = output.isExpanded.value
+        chattingList.isHidden = output.isExpanded.value
         chatInputField.isHidden = output.isExpanded.value
         infoView.isHidden = output.isExpanded.value
         if output.isExpanded.value {
@@ -55,7 +55,7 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
     public override func setupViews() {
         view.addSubview(infoView)
         view.addSubview(playerView)
-        view.addSubview(chatingList)
+        view.addSubview(chattingList)
         view.addSubview(chatInputField)
     }
     
@@ -87,7 +87,7 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
             $0.horizontal(to: view)
         }
         
-        chatingList.ezl.makeConstraint {
+        chattingList.ezl.makeConstraint {
             $0.top(to: infoView.ezl.bottom, offset: 24)
                 .horizontal(to: view)
                 .bottom(to: chatInputField.ezl.top)
@@ -151,7 +151,7 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
         
         output.chatList
             .sink { [weak self] in
-                self?.chatingList.updateList($0)
+                self?.chattingList.updateList($0)
             }
             .store(in: &subscription)
         

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
@@ -36,6 +36,11 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
         print("Deinit \(Self.self)")
     }
     
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        viewDidLoadPublisher.send(())
+    }
+    
     public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return output.isExpanded.value ? .landscapeLeft: .portrait
     }
@@ -153,6 +158,7 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
             .store(in: &subscription)
         
         output.chatList
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.chattingList.updateList($0)
             }

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
@@ -22,6 +22,7 @@ public final class LiveStreamViewModel: ViewModel {
         let dismissButtonDidTap: AnyPublisher<Void?, Never>
         let chattingSendButtonDidTap: AnyPublisher<ChatInfo?, Never>
         let autoDissmissDidRegister: PassthroughSubject<Void, Never> = .init()
+        let viewDidLoad: AnyPublisher<Void, Never>
     }
     
     public struct Output {

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
@@ -9,10 +9,6 @@ public final class LiveStreamViewModel: ViewModel {
     
     private var subscription = Set<AnyCancellable>()
     
-    // MARK: - 추후 제거
-    let makeChatRoomUseCase: any MakeChatRoomUseCase
-    let deleteChatRoomUseCase: any DeleteChatRoomUseCase
-    
     private let chattingSocket: WebSocket
     
     private let channelID: String
@@ -40,14 +36,10 @@ public final class LiveStreamViewModel: ViewModel {
     
     public init(
         channelID: String,
-        chattingSocket: WebSocket = .shared,
-        makeChatRoomUseCase: any MakeChatRoomUseCase,
-        deleteChatRoomUseCase: any DeleteChatRoomUseCase
+        chattingSocket: WebSocket = .shared
     ) {
         self.channelID = channelID
         self.chattingSocket = chattingSocket
-        self.makeChatRoomUseCase = makeChatRoomUseCase
-        self.deleteChatRoomUseCase = deleteChatRoomUseCase
     }
     
     deinit {

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
@@ -2,6 +2,7 @@ import Combine
 import Foundation
 
 import BaseFeatureInterface
+import ChatSoketModule
 import ChattingDomainInterface
 
 public final class LiveStreamViewModel: ViewModel {
@@ -11,6 +12,10 @@ public final class LiveStreamViewModel: ViewModel {
     // MARK: - 추후 제거
     let makeChatRoomUseCase: any MakeChatRoomUseCase
     let deleteChatRoomUseCase: any DeleteChatRoomUseCase
+    
+    private let chattingSocket: WebSocket
+    
+    private let channelID: String
         
     public struct Input {
         let expandButtonDidTap: AnyPublisher<Void?, Never>
@@ -33,7 +38,14 @@ public final class LiveStreamViewModel: ViewModel {
         let dismiss: PassthroughSubject<Void, Never> = .init()
     }
     
-    public init(makeChatRoomUseCase: any MakeChatRoomUseCase, deleteChatRoomUseCase: any DeleteChatRoomUseCase) {
+    public init(
+        channelID: String,
+        chattingSocket: WebSocket = .shared,
+        makeChatRoomUseCase: any MakeChatRoomUseCase,
+        deleteChatRoomUseCase: any DeleteChatRoomUseCase
+    ) {
+        self.channelID = channelID
+        self.chattingSocket = chattingSocket
         self.makeChatRoomUseCase = makeChatRoomUseCase
         self.deleteChatRoomUseCase = deleteChatRoomUseCase
     }

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
@@ -19,7 +19,7 @@ public final class LiveStreamViewModel: ViewModel {
         let playerGestureDidTap: AnyPublisher<Void?, Never>
         let playButtonDidTap: AnyPublisher<Void?, Never>
         let dismissButtonDidTap: AnyPublisher<Void?, Never>
-        let chatingSendButtonDidTap: AnyPublisher<ChatInfo?, Never>
+        let chattingSendButtonDidTap: AnyPublisher<ChatInfo?, Never>
         let autoDissmissDidRegister: PassthroughSubject<Void, Never> = .init()
     }
     
@@ -103,7 +103,7 @@ public final class LiveStreamViewModel: ViewModel {
             }
             .store(in: &subscription)
         
-        input.chatingSendButtonDidTap
+        input.chattingSendButtonDidTap
             .sink { chatInfo in
              }
              .store(in: &subscription)

--- a/Projects/Features/MainFeature/Demo/Sources/MockLiveStreamViewControllerFactory.swift
+++ b/Projects/Features/MainFeature/Demo/Sources/MockLiveStreamViewControllerFactory.swift
@@ -5,7 +5,7 @@ import LiveStreamFeatureInterface
 public struct MockLiveStreamViewControllerFractoryImpl: LiveStreamViewControllerFactory {
     public init() { }
     
-    public func make() -> UIViewController {
+    public func make(channelID: String) -> UIViewController {
         let viewModel = MockLiveStreamViewModel()
         return MockLiveStreamViewController(viewModel: viewModel)
     }

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
@@ -129,7 +129,8 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
 // MARK: - CollectionView Delegate
 extension BroadcastCollectionViewController: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let viewController = factory?.make() else { return }
+        #warning("화면 전환 시 선택한 Cell의 channelID 주입")
+        guard let viewController = factory?.make(channelID: "1234") else { return }
         viewController.modalPresentationStyle = .overCurrentContext
         viewController.transitioningDelegate = transitioning
         present(viewController, animated: true)

--- a/Projects/Modules/ChatSoketModule/Sources/Message/ChatMessage.swift
+++ b/Projects/Modules/ChatSoketModule/Sources/Message/ChatMessage.swift
@@ -1,8 +1,15 @@
 import Foundation
 
-struct ChatMessage: Codable {
-    var type: MessageType
-    var content: String?
-    var sender: String
-    var roomId: String
+public struct ChatMessage: Codable {
+    public let type: MessageType
+    public let content: String?
+    public let sender: String
+    public let roomId: String
+    
+    public init(type: MessageType, content: String?, sender: String, roomId: String) {
+        self.type = type
+        self.content = content
+        self.sender = sender
+        self.roomId = roomId
+    }
 }

--- a/Projects/Modules/ChatSoketModule/Sources/Message/MessageType.swift
+++ b/Projects/Modules/ChatSoketModule/Sources/Message/MessageType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum MessageType: String, Codable {
+public enum MessageType: String, Codable {
     case ENTER
     case CHAT
     case LEAVE

--- a/Projects/Modules/ChatSoketModule/Sources/WebSocket.swift
+++ b/Projects/Modules/ChatSoketModule/Sources/WebSocket.swift
@@ -4,8 +4,8 @@ enum WebSocketError: Error {
     case invalidURL
 }
 
-final class WebSocket: NSObject {
-    static let shared = WebSocket()
+public final class WebSocket: NSObject {
+    public static let shared = WebSocket()
     
     var url: URL?
     var onReceiveClosure: ((ChatMessage?) -> Void)?
@@ -21,7 +21,7 @@ final class WebSocket: NSObject {
     
     private override init() {}
     
-    func openWebSocket() throws {
+    public func openWebSocket() throws {
         url = URL(string: "ws:/\(host):\(port)/ws/chat" )
         guard let url = url else { throw WebSocketError.invalidURL }
         
@@ -36,10 +36,9 @@ final class WebSocket: NSObject {
         self.webSocketTask = webSocketTask
         
         self.startPing()
-        
     }
 
-    func send(data: ChatMessage) {
+    public func send(data: ChatMessage) {
         guard let data = try? encoder.encode(data) else { return }
         
         let taskMessage = URLSessionWebSocketTask.Message.data(data)
@@ -50,7 +49,7 @@ final class WebSocket: NSObject {
         }
     }
     
-    func closeWebSocket() {
+    public func closeWebSocket() {
         self.webSocketTask = nil
         self.timer?.invalidate()
         self.onReceiveClosure = nil
@@ -59,7 +58,7 @@ final class WebSocket: NSObject {
         self.webSocketTask = nil
     }
     
-    func receive(onReceive: @escaping ((ChatMessage?) -> Void)) {
+    public func receive(onReceive: @escaping ((ChatMessage?) -> Void)) {
         self.onReceiveClosure = onReceive
         self.webSocketTask?.receive { [weak self] result in
             print("Receive \(result)")
@@ -108,7 +107,7 @@ final class WebSocket: NSObject {
 }
 
 extension WebSocket: URLSessionWebSocketDelegate {
-    func urlSession(
+    public func urlSession(
         _ session: URLSession,
         webSocketTask: URLSessionWebSocketTask,
         didOpenWithProtocol protocol: String?
@@ -120,7 +119,7 @@ extension WebSocket: URLSessionWebSocketDelegate {
         )
     }
     
-    func urlSession(
+    public func urlSession(
         _ session: URLSession,
         webSocketTask: URLSessionWebSocketTask,
         didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 

- Resolves: #199

## 📃 작업내용

https://github.com/user-attachments/assets/dcc7c445-ebc0-47cc-bdd3-0b93c6094a37


- `ChatSocketModule`의 `WebSocket`과 `LiveStreamFeature`의 `LiveStreamViewModel` 연결하였습니다.

소켓 연결의 경우 `LiveStreamViewController`에서 `viewDidLoadPublisher` input을 생성하여 `viewDidLoad` 시점에 이벤트를 ViewModel에게 전달

 ```swift
  private let viewDidLoadPublisher = PassthroughSubject<Void, Never>()
    private lazy var input = LiveStreamViewModel.Input(
        //..중략
        viewDidLoad: viewDidLoadPublisher.eraseToAnyPublisher()
    )
        
    deinit {...}
    
    public override func viewDidLoad() {
        super.viewDidLoad()
        viewDidLoadPublisher.send(())
    }
```

viewModel의 경우 이벤트를 전달 받으면. 소켓을 열고, 입장에 대한 메시지를 서버에 전송 및 서버에서 데이터를 받을 준비를 합니다.

  ```swift
  input.viewDidLoad
            .sink { [weak self] _ in
                guard let self else { return }
                
                do {
                    try chattingSocket.openWebSocket() // 소켓 연결
                } catch {
                    output.error.send(error) // 에러 처리
                }
                
                chattingSocket.send( // 입장 메시지 전송
                    data: ChatMessage(
                        type: .ENTER,
                        content: "XXX님이 입장하셨습니다.",
                        sender: channelID,
                        roomId: channelID
                    )
                )
                
                chattingSocket.receive { chatMessage in // 서버로 부터 데이터를 받을 준비
                    guard let chatMessage else { return }
                    var chatList = output.chatList.value
                    chatList.append(ChatInfo(name: chatMessage.sender, message: chatMessage.content ?? ""))
                    output.chatList.send(chatList)
                }
            }
            .store(in: &subscription)
```

사용자가 입력창에 내용을 입력 후 보내기 버튼 클릭 시 해당 내용을 서버에게 전달

```swift
        input.chattingSendButtonDidTap
            .sink { [weak self] chatInfo in
                guard let chatInfo,
                      let self else { return }
                chattingSocket.send(
                    data: ChatMessage(
                        type: .CHAT,
                        content: chatInfo.message,
                        sender: chatInfo.name,
                        roomId: channelID
                    )
                )
             }
             .store(in: &subscription)
```

- LiveStreamFeature ChattingDomain 의존성 제거

![image](https://github.com/user-attachments/assets/4dd489ae-9171-4782-aec6-305ad373bf59)

## 🙋‍♂️ 리뷰노트

@yongbeomkwak ChatSocketModule 소스코드 중 접근제어자가 `internal`로 설정되어 있는 부분 수정했습니다.

@hyunjuntyler 현준님 `factory`의 `make` 인터페이스가 수정되면서 아래와 같이 임시로 수정했습니다.

```swift
//BroadcastCollectionViewController.swift

// MARK: - CollectionView Delegate
extension BroadcastCollectionViewController: UICollectionViewDelegate {
    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
        #warning("화면 전환 시 선택한 Cell의 channelID 주입")
        guard let viewController = factory?.make(channelID: "1234") else { return }
        viewController.modalPresentationStyle = .overCurrentContext
        viewController.transitioningDelegate = transitioning
        present(viewController, animated: true)
    }
}
```

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
