### PR TITLE
task #203 Viewmodel 연결 전 변경된 로직에 맞게 기존 코드를 수정

### DIFF
--- a/Projects/App/Sources/MockFetchChannelListUsecaseImpl.swift
+++ b/Projects/App/Sources/MockFetchChannelListUsecaseImpl.swift
@@ -53,7 +53,7 @@ final class MockChannelListFetcher {
             let image: Image = randomBool ? .ratio16x9 : .ratio4x3
             let fetchedImage = await image.fetch()
 
-            channels.append(ChannelEntity(id: UUID().uuidString, name: name, image: fetchedImage))
+            channels.append(ChannelEntity(id: UUID().uuidString, name: name))
         }
 
         return channels

--- a/Projects/Domains/LiveStationDomain/Interface/Entity/ChannelEntity.swift
+++ b/Projects/Domains/LiveStationDomain/Interface/Entity/ChannelEntity.swift
@@ -3,11 +3,9 @@ import UIKit
 public struct ChannelEntity {
     public let id: String
     public let name: String
-    public let image: UIImage?
     
-    public init(id: String, name: String, image: UIImage? = nil) {
+    public init(id: String, name: String) {
         self.id = id
         self.name = name
-        self.image = image
     }
 }

--- a/Projects/Domains/LiveStationDomain/Interface/Repository/LiveStationRepository.swift
+++ b/Projects/Domains/LiveStationDomain/Interface/Repository/LiveStationRepository.swift
@@ -2,7 +2,7 @@ import Combine
 
 public protocol LiveStationRepository {
     func fetchChannelList() -> AnyPublisher<[ChannelEntity], Error>
-    func fetchThumbnail(channelId: String) -> AnyPublisher<[String], any Error>
+    func fetchThumbnail(channelId: String) -> AnyPublisher<String, any Error>
     func receiveBroadcast(channelId: String) -> AnyPublisher<[BroadcastEntity], any Error>
     func createChannel(name: String) -> AnyPublisher<ChannelEntity, any Error>
     func deleteChannel(id: String) -> AnyPublisher<ChannelEntity, any Error>

--- a/Projects/Domains/LiveStationDomain/Sources/Endpoint/LiveStationEndpoint.swift
+++ b/Projects/Domains/LiveStationDomain/Sources/Endpoint/LiveStationEndpoint.swift
@@ -37,14 +37,17 @@ extension LiveStationEndpoint: Endpoint {
     public var path: String {
         switch self {
         case .fetchChannelList, .makeChannel: "/api/v2/channels"
-        case let .receiveBroadcast(channelId), let .fetchThumbnail(channelId): "/api/v2/broadcasts/\(channelId)/serviceUrls"
+        case let .receiveBroadcast(channelId), let .fetchThumbnail(channelId): "/api/v2/channels/\(channelId)/serviceUrls"
         case let .deleteChannel(channelId): "/api/v2/channels/\(channelId)"
         }
     }
     
     public var requestTask: NetworkModule.RequestTask {
         switch self {
-        case .fetchChannelList: return .empty
+        case .fetchChannelList:
+            return .withParameters(
+                query: ["channelStatus": "PUBLISHING"]
+            )
             
         case .receiveBroadcast:
             return .withParameters(

--- a/Projects/Domains/LiveStationDomain/Sources/Repository/LiveStationRepositoryImpl.swift
+++ b/Projects/Domains/LiveStationDomain/Sources/Repository/LiveStationRepositoryImpl.swift
@@ -10,9 +10,9 @@ public final class LiveStationRepositoryImpl: BaseRepository<LiveStationEndpoint
             .eraseToAnyPublisher()
     }
     
-    public func fetchThumbnail(channelId: String) -> AnyPublisher<[String], any Error> {
+    public func fetchThumbnail(channelId: String) -> AnyPublisher<String, any Error> {
         return request(.fetchThumbnail(channelId: channelId), type: ThumbnailResponseDTO.self)
-            .map { $0.content.map { $0.toDomain() }}
+            .compactMap { $0.content.first?.toDomain() }
             .eraseToAnyPublisher()
     }
     

--- a/Projects/Features/MainFeature/Demo/Sources/MockFetchChannelListUsecaseImpl.swift
+++ b/Projects/Features/MainFeature/Demo/Sources/MockFetchChannelListUsecaseImpl.swift
@@ -53,7 +53,7 @@ final class MockChannelListFetcher {
             let image: Image = randomBool ? .ratio16x9 : .ratio4x3
             let fetchedImage = await image.fetch()
 
-            channels.append(ChannelEntity(id: UUID().uuidString, name: name, image: fetchedImage))
+            channels.append(ChannelEntity(id: UUID().uuidString, name: name))
         }
 
         return channels

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
@@ -209,7 +209,7 @@ extension BroadcastCollectionViewController {
                 ) as? LargeBroadcastCollectionViewCell else {
                     return UICollectionViewCell()
                 }
-                bigCell.configure(image: item.image, title: item.name)
+                bigCell.configure(id: item.id, title: item.name, viewmodel: self.viewModel)
                 return bigCell
                 
             case .small:
@@ -219,7 +219,7 @@ extension BroadcastCollectionViewController {
                 ) as? SmallBroadcastCollectionViewCell else {
                     return UICollectionViewCell()
                 }
-                smallCell.configure(image: item.image, title: item.name)
+                smallCell.configure(id: item.id, title: item.name, viewmodel: self.viewModel)
                 return smallCell
             }
         }

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
@@ -5,12 +5,11 @@ import BaseFeatureInterface
 import LiveStationDomainInterface
 
 public struct Channel: Hashable {
-    let id = UUID().uuidString
+    let id: String
     var name: String
-    var image: UIImage?
     
-    public init(title: String, image: UIImage? = nil) {
-        self.image = image
+    public init(id: String, title: String) {
+        self.id = id
         self.name = title
     }
 }

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
@@ -78,7 +78,7 @@ public class BroadcastCollectionViewModel: ViewModel {
                 receiveCompletion: { _ in },
                 receiveValue: { entity in
                     self.output.channels.send(entity.map {
-                        Channel(title: $0.name, image: $0.image)
+                        Channel(id: $0.id, title: $0.name)
                     })
                 }
             )

--- a/Projects/Features/MainFeature/Sources/LargeBroadcastCollectionViewCell.swift
+++ b/Projects/Features/MainFeature/Sources/LargeBroadcastCollectionViewCell.swift
@@ -52,8 +52,6 @@ final class LargeBroadcastCollectionViewCell: BaseCollectionViewCell, ThumbnailV
         titleLabel.lineBreakMode = .byWordWrapping
     }
     
-    func configure(image: UIImage?, title: String) {
-        self.thumbnailView.configure(with: image)
-        self.titleLabel.text = title
+    func configure(id: String, title: String, viewmodel: BroadcastCollectionViewModel) {
     }
 }

--- a/Projects/Features/MainFeature/Sources/SmallBroadcastCollectionViewCell.swift
+++ b/Projects/Features/MainFeature/Sources/SmallBroadcastCollectionViewCell.swift
@@ -58,8 +58,6 @@ final class SmallBroadcastCollectionViewCell: BaseCollectionViewCell, ThumbnailV
         titleLabel.numberOfLines = 2
     }
     
-    func configure(image: UIImage?, title: String) {
-        self.thumbnailView.configure(with: image)
-        self.titleLabel.text = title
+    func configure(id: String, title: String, viewmodel: BroadcastCollectionViewModel) {
     }
 }


### PR DESCRIPTION
## 💡 요약 및 이슈 

### Viewmodel 연결 전 변경된 로직에 맞게 기존 코드를 수정했습니다.

- Resolves: #203

## 📃 작업내용

- 채널에서 image 삭제
- 잘못된 Endpoint 수정
- 파라미터 변경

## 🙋‍♂️ 리뷰노트

- PR을 최대한 작게 나눠서 올리는데 보기 괜찮으신가요?

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
