### PR TITLE
task #218 데이터 로딩중인 뷰 구현

### DIFF
--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionLoadView.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionLoadView.swift
@@ -1,0 +1,36 @@
+import UIKit
+
+import BaseFeature
+import DesignSystem
+
+final class BroadcastCollectionLoadView: BaseView {
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    
+    private lazy var textStackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+    
+    override func setupViews() {
+        addSubview(textStackView)
+        
+        titleLabel.text = "방송을 불러오는 중이에요!"
+        
+        subtitleLabel.text = "잠시만 기다려주세요!"
+    }
+    
+    override func setupStyles() {
+        titleLabel.textColor = .white
+        titleLabel.font = .setFont(.title())
+        
+        subtitleLabel.textColor = .gray
+        subtitleLabel.font = .setFont(.body2())
+        
+        textStackView.axis = .vertical
+        textStackView.spacing = 12
+    }
+    
+    override func setupLayouts() {
+        textStackView.ezl.makeConstraint {
+            $0.center(to: self)
+        }
+    }
+}

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
@@ -64,16 +64,16 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
         navigationItem.rightBarButtonItem = rightBarButton
         
         collectionView.refreshControl = refreshControl
-        
         collectionView.delegate = self
-        
         collectionView.register(LargeBroadcastCollectionViewCell.self, forCellWithReuseIdentifier: LargeBroadcastCollectionViewCell.identifier)
         collectionView.register(SmallBroadcastCollectionViewCell.self, forCellWithReuseIdentifier: SmallBroadcastCollectionViewCell.identifier)
         collectionView.register(UICollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "Header")
+        collectionView.isHidden = true
         
         emptyView.isHidden = true
-        
+                
         view.addSubview(emptyView)
+        view.addSubview(dataLoadView)
         view.addSubview(collectionView)
     }
     
@@ -99,6 +99,10 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
         }
         
         emptyView.ezl.makeConstraint {
+            $0.diagonal(to: view)
+        }
+        
+        dataLoadView.ezl.makeConstraint {
             $0.diagonal(to: view)
         }
     }

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
@@ -252,6 +252,8 @@ extension BroadcastCollectionViewController {
     }
     
     private func applySnapshot(with channels: [Channel]) {
+        dataLoadView.isHidden = true
+        
         if channels.isEmpty {
             collectionView.isHidden = true
             emptyView.isHidden = false

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
@@ -29,6 +29,7 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
     private let transitioning = CollectionViewCellTransitioning()
     
     private let emptyView = BroadcastCollectionEmptyView()
+    private let dataLoadView = BroadcastCollectionLoadView()
     
     var selectedThumbnailView: ThumbnailView? {
         guard let indexPath = collectionView.indexPathsForSelectedItems?.first else { return nil }


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 데이터 로딩될 동안 보여질 뷰를 구현했습니다.

- Resolves: #218

## 📃 작업내용

- 뷰 구현
- 뷰컨트롤러에 추가

## 🙋‍♂️ 리뷰노트

- 로딩뷰인만큼 이미지가 아니라 lottie로 동적이게 넣으면 어떨까 싶어서 일단 텍스트만 넣어뒀습니다! 의견주시면 감사하겠습니다!

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
