### PR TITLE
task #230 레포지토리와 usecase 구현

### DIFF
--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -51,14 +51,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 extension SceneDelegate {
     private func registerDependencies() {
-        let chatRepositoryImpl: any ChatRepository = ChatRepositoryImpl()
-        let makeRoomUseCase: any MakeChatRoomUseCase = MakeChatRoomUseCaseImpl(repository: chatRepositoryImpl)
-        let deleteRoomUseCase: any DeleteChatRoomUseCase = DeleteChatRoomUseCaseImpl(repository: chatRepositoryImpl)
-        let liveStreamFactoryImpl = LiveStreamViewControllerFractoryImpl(makeChatRoomUseCase: makeRoomUseCase, deleteChatRoomUseCase: deleteRoomUseCase)
-        DIContainer.shared.register(LiveStreamViewControllerFactory.self, dependency: liveStreamFactoryImpl)
-        
         let liveStationRepository = LiveStationRepositoryImpl()
         let fetchChannelListUsecaseImpl = FetchChannelListUsecaseImpl(repository: liveStationRepository)
         DIContainer.shared.register(FetchChannelListUsecase.self, dependency: fetchChannelListUsecaseImpl)
+        
+        let chatRepositoryImpl: any ChatRepository = ChatRepositoryImpl()
+        let makeRoomUseCase: any MakeChatRoomUseCase = MakeChatRoomUseCaseImpl(repository: chatRepositoryImpl)
+        let deleteRoomUseCase: any DeleteChatRoomUseCase = DeleteChatRoomUseCaseImpl(repository: chatRepositoryImpl)
+        let fetchBroadcastUseCase: any FetchVideoListUsecase = FetchVideoListUsecaseImpl(repository: liveStationRepository)
+        let liveStreamFactoryImpl = LiveStreamViewControllerFractoryImpl(makeChatRoomUseCase: makeRoomUseCase, deleteChatRoomUseCase: deleteRoomUseCase, fetchBroadcastUseCase: fetchBroadcastUseCase)
+        DIContainer.shared.register(LiveStreamViewControllerFactory.self, dependency: liveStreamFactoryImpl)
     }
 }

--- a/Projects/Features/LiveStreamFeature/Interface/LiveStreamViewControllerFactory.swift
+++ b/Projects/Features/LiveStreamFeature/Interface/LiveStreamViewControllerFactory.swift
@@ -3,5 +3,5 @@ import UIKit
 import BaseFeatureInterface
 
 public protocol LiveStreamViewControllerFactory {
-    func make() -> UIViewController
+    func make(channelID: String) -> UIViewController
 }

--- a/Projects/Features/LiveStreamFeature/Sources/Factory/LiveStreamViewControllerFractoryImpl.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Factory/LiveStreamViewControllerFractoryImpl.swift
@@ -2,20 +2,26 @@ import UIKit
 
 import BaseFeatureInterface
 import ChattingDomainInterface
+import LiveStationDomainInterface
 import LiveStreamFeatureInterface
 
 public struct LiveStreamViewControllerFractoryImpl: LiveStreamViewControllerFactory {
-    
     private let makeChatRoomUseCase: any MakeChatRoomUseCase
     private let deleteChatRoomUseCase: any DeleteChatRoomUseCase
+    private let fetchBroadcastUseCase: any FetchVideoListUsecase
     
-    public init(makeChatRoomUseCase: any MakeChatRoomUseCase, deleteChatRoomUseCase: DeleteChatRoomUseCase) {
+    public init(
+        makeChatRoomUseCase: any MakeChatRoomUseCase,
+        deleteChatRoomUseCase: DeleteChatRoomUseCase,
+        fetchBroadcastUseCase: any FetchVideoListUsecase
+    ) {
         self.makeChatRoomUseCase = makeChatRoomUseCase
         self.deleteChatRoomUseCase = deleteChatRoomUseCase
+        self.fetchBroadcastUseCase = fetchBroadcastUseCase
     }
     
-    public func make() -> UIViewController {
-        let viewModel = LiveStreamViewModel(makeChatRoomUseCase: makeChatRoomUseCase, deleteChatRoomUseCase: deleteChatRoomUseCase)
+    public func make(channelID: String) -> UIViewController {
+        let viewModel = LiveStreamViewModel(makeChatRoomUseCase: makeChatRoomUseCase, deleteChatRoomUseCase: deleteChatRoomUseCase, fetchBroadcastUseCase: fetchBroadcastUseCase, channelID: channelID)
         return LiveStreamViewController(viewModel: viewModel)
     }
 }

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewModels/LiveStreamViewModel.swift
@@ -3,6 +3,7 @@ import Foundation
 
 import BaseFeatureInterface
 import ChattingDomainInterface
+import LiveStationDomainInterface
 
 public final class LiveStreamViewModel: ViewModel {
     
@@ -11,7 +12,10 @@ public final class LiveStreamViewModel: ViewModel {
     // MARK: - 추후 제거
     let makeChatRoomUseCase: any MakeChatRoomUseCase
     let deleteChatRoomUseCase: any DeleteChatRoomUseCase
-        
+    let fetchBroadcastUseCase: any FetchVideoListUsecase
+    
+    private let output = Output()
+
     public struct Input {
         let expandButtonDidTap: AnyPublisher<Void?, Never>
         let sliderValueDidChange: AnyPublisher<Float?, Never>
@@ -31,11 +35,19 @@ public final class LiveStreamViewModel: ViewModel {
         let isShowedPlayerControl: CurrentValueSubject<Bool, Never> = .init(false)
         let isShowedInfoView: CurrentValueSubject<Bool, Never> = .init(false)
         let dismiss: PassthroughSubject<Void, Never> = .init()
+        let videoURLString: PassthroughSubject<String, Never> = .init()
     }
     
-    public init(makeChatRoomUseCase: any MakeChatRoomUseCase, deleteChatRoomUseCase: any DeleteChatRoomUseCase) {
+    public init(
+        makeChatRoomUseCase: any MakeChatRoomUseCase,
+        deleteChatRoomUseCase: any DeleteChatRoomUseCase,
+        fetchBroadcastUseCase: any FetchVideoListUsecase,
+        channelID: String
+    ) {
         self.makeChatRoomUseCase = makeChatRoomUseCase
         self.deleteChatRoomUseCase = deleteChatRoomUseCase
+        self.fetchBroadcastUseCase = fetchBroadcastUseCase
+        fetchVideoData(channelID: channelID)
     }
     
     deinit {
@@ -43,15 +55,13 @@ public final class LiveStreamViewModel: ViewModel {
     }
     
     public func transform(input: Input) -> Output {
-        let output = Output()
-        
         input.expandButtonDidTap
             .compactMap { $0 }
             .sink {
-                let nextValue = !output.isExpanded.value
-                output.isExpanded.send(nextValue)
-                output.isShowedPlayerControl.send(false)
-                output.isShowedInfoView.send(false)
+                let nextValue = !self.output.isExpanded.value
+                self.output.isExpanded.send(nextValue)
+                self.output.isShowedPlayerControl.send(false)
+                self.output.isShowedInfoView.send(false)
             }
             .store(in: &subscription)
         
@@ -60,31 +70,31 @@ public final class LiveStreamViewModel: ViewModel {
             .map { Double($0) }
             .sink {
                 input.autoDissmissDidRegister.send()
-                output.time.send($0)
+                self.output.time.send($0)
             }
             .store(in: &subscription)
         
         input.playerStateDidChange
             .compactMap { $0 }
             .sink { flag in
-                output.isPlaying.send(flag)
+                self.output.isPlaying.send(flag)
             }
             .store(in: &subscription)
         
         input.playerGestureDidTap
             .compactMap { $0 }
             .sink { _ in
-                let nextValue1 = !output.isShowedPlayerControl.value
-                output.isShowedPlayerControl.send(nextValue1)
+                let nextValue1 = !self.output.isShowedPlayerControl.value
+                self.output.isShowedPlayerControl.send(nextValue1)
                 
                 if nextValue1 {
                     input.autoDissmissDidRegister.send()
                 }
                 
-                if output.isExpanded.value {
-                    output.isShowedInfoView.send(false)
+                if self.output.isExpanded.value {
+                    self.output.isShowedInfoView.send(false)
                 } else {
-                    output.isShowedInfoView.send(!output.isShowedInfoView.value)
+                    self.output.isShowedInfoView.send(!self.output.isShowedInfoView.value)
                 }
             }
             .store(in: &subscription)
@@ -93,13 +103,13 @@ public final class LiveStreamViewModel: ViewModel {
             .compactMap { $0 }
             .sink { _ in
                 input.autoDissmissDidRegister.send()
-                output.isPlaying.send(!output.isPlaying.value)
+                self.output.isPlaying.send(!self.output.isPlaying.value)
             }
             .store(in: &subscription)
         
         input.dismissButtonDidTap
             .sink { _ in
-                output.dismiss.send()
+                self.output.dismiss.send()
             }
             .store(in: &subscription)
         
@@ -111,11 +121,26 @@ public final class LiveStreamViewModel: ViewModel {
         input.autoDissmissDidRegister
             .debounce(for: .seconds(3), scheduler: DispatchQueue.main)
             .sink { _ in
-                output.isShowedPlayerControl.send(false)
-                output.isShowedInfoView.send(false)
+                self.output.isShowedPlayerControl.send(false)
+                self.output.isShowedInfoView.send(false)
             }
             .store(in: &subscription)
         
         return output
+    }
+    
+    private func fetchVideoData(channelID: String) {
+        fetchBroadcastUseCase.execute(channelID: channelID)
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { entityList in
+                    let entity = entityList.filter { $0.name == "ABR" }.first
+                    if let entity {
+                        return self.output.videoURLString.send(entity.videoURLString)
+                    } else if let lowResolution = entityList.first?.videoURLString {
+                        return self.output.videoURLString.send(lowResolution)
+                    }
+                    })
+            .store(in: &subscription)
     }
 }

--- a/Projects/Features/MainFeature/Demo/Sources/MockLiveStreamViewControllerFactory.swift
+++ b/Projects/Features/MainFeature/Demo/Sources/MockLiveStreamViewControllerFactory.swift
@@ -5,7 +5,7 @@ import LiveStreamFeatureInterface
 public struct MockLiveStreamViewControllerFractoryImpl: LiveStreamViewControllerFactory {
     public init() { }
     
-    public func make() -> UIViewController {
+    public func make(channelID: String) -> UIViewController {
         let viewModel = MockLiveStreamViewModel()
         return MockLiveStreamViewController(viewModel: viewModel)
     }

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewController.swift
@@ -143,7 +143,8 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
 // MARK: - CollectionView Delegate
 extension BroadcastCollectionViewController: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let viewController = factory?.make() else { return }
+        guard let channel = dataSource?.itemIdentifier(for: indexPath) else { return }
+        guard let viewController = factory?.make(channelID: channel.id) else { return }
         viewController.modalPresentationStyle = .overCurrentContext
         viewController.transitioningDelegate = transitioning
         present(viewController, animated: true)


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 영상을 로드하기 위해 레포지토리쪽과 Usecase를 수정했습니다

- Resolves: #230 

## 📃 작업내용

- usecase 수정
- 파라미터 추가

## 🙋‍♂️ 리뷰노트

뷰모델 생성자에서 채널 ID를 받아서 비디오를 가져오는 메소드를 바로 실행시키는데, ViewModel의 역할이 너무 많아지는 것 같다는 느낌이 듭니다! 저만 그렇게 느끼는 건지 다른 분들도 그렇게 느끼시는지 궁금합니다.

```Swift
   public init(
        // 중략.. (usecase들 받는 부분)
        channelID: String
    ) {
        // 중략.. (usecase들 할당하는 부분)
        fetchVideoData(channelID: channelID)
    }
```

```Swift
  private func fetchVideoData(channelID: String) {
        fetchBroadcastUseCase.execute(channelID: channelID)
            .sink(
                receiveCompletion: { _ in },
                receiveValue: { entityList in
                    let entity = entityList.filter { $0.name == "ABR" }.first
                    if let entity {
                        return self.output.videoURLString.send(entity.videoURLString)
                    } else if let lowResolution = entityList.first?.videoURLString {
                        return self.output.videoURLString.send(lowResolution)
                    }
                    })
            .store(in: &subscription)
    }
```

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
