### PR TITLE
task 플레이어의 되감기 기능을 가능하게 버그를 수정합니다.

### DIFF
--- a/Projects/Features/LiveStreamFeature/Sources/Player/Views/ShookPlayerView.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/Views/ShookPlayerView.swift
@@ -199,12 +199,9 @@ extension ShookPlayerView {
         switch bufferString {
         case "playbackBufferEmpty":
             indicatorView.startAnimating()
-            
-        case "playbackLikelyToKeepUp", "playbackBufferFull":
-            indicatorView.stopAnimating()
-            
+    
         default:
-            return
+            indicatorView.stopAnimating()
         }
     }
     
@@ -212,6 +209,7 @@ extension ShookPlayerView {
         switch status {
         case .playing:
             playingStateChangedPublisher = true
+            indicatorView.stopAnimating()
             
         case.paused:
             playingStateChangedPublisher = false

--- a/Projects/Features/LiveStreamFeature/Sources/Player/Views/ShookPlayerView.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/Views/ShookPlayerView.swift
@@ -32,8 +32,6 @@ final class ShookPlayerView: BaseView {
     private let indicatorView: UIActivityIndicatorView =  UIActivityIndicatorView()
     private var timeObserverToken: Any?
     private var subscription: Set<AnyCancellable> = .init()
-    private var isInitialized = false
-    private var isURLSet = false
     
     // MARK: - @Published
     @Published private var playingStateChangedPublisher: Bool?
@@ -55,7 +53,6 @@ final class ShookPlayerView: BaseView {
     
     override init() {
         super.init(frame: .zero)
-        addObserver()
     }
     
     func stopPlayback() {
@@ -66,6 +63,7 @@ final class ShookPlayerView: BaseView {
     func fetchVideo(m3u8URL: URL) {
         playerItem = AVPlayerItem(url: m3u8URL)
         player.replaceCurrentItem(with: playerItem)
+        addObserver()
         player.play()
     }
     
@@ -182,8 +180,12 @@ extension ShookPlayerView {
         switch status {
         case .readyToPlay: // 성공
             guard let playerItem else { return }
-            playerControlView.timeControlView.maxValue = Float(CMTimeGetSeconds(playerItem.duration))
-            
+            guard let item = player.currentItem else {
+                return
+            }
+    
+            let seekableDuration = item.seekableTimeRanges.last?.timeRangeValue.end.seconds ?? 0.0
+            playerControlView.timeControlView.maxValue = Float(seekableDuration) // HLS 사용 시 seek 가능한 영역 갱신
         case.failed, .unknown:
         #warning("에러")
             break


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 최대 시청 가능 영역이 계속 0인 상태 였습니다.


<img width="762" alt="스크린샷 2024-11-27 오후 8 18 51" src="https://github.com/user-attachments/assets/9acfef44-1638-418d-94bc-20bff76c48eb">

여기서 기존에 로컬에서 테스트 했을 때 잘됐던 이유는 VOD 같은 느낌이라 duration에 잘 들어왔는데

실시간 스트리밍은 저 값을 쓰면 Nan으로 들어와 앱이 터지는 오류가 있엇습니다.

그래서 찾아보니 seekableTimeRanges라는 값이 있고 이값은  되돌아 갈수 있는 범위가 저장된 배열입낟.

여기서 마지막 부분은 end 값이 가장 최신 값 입니다.

- Resolves: #240 

## 📃 작업내용

https://github.com/user-attachments/assets/c8d75d0d-ba8d-4a24-bc82-0d77f2df91dc

해골물인 최대 값 범위를 수정했습니다.

## 🙋‍♂️ 리뷰노트

@hyunjuntyler  deinit과 observer 해제 부분 통합해서 테스트 다시 해봐야할 듯 합니다..

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
