### PR TITLE
task #252 App과 Extension과 RTMP URL 및 StreamKey 공유

### DIFF
--- a/Projects/App/BroadcastUploadExtension/Sources/SampleHandler.swift
+++ b/Projects/App/BroadcastUploadExtension/Sources/SampleHandler.swift
@@ -15,7 +15,7 @@ final class SampleHandler: RPBroadcastSampleHandler {
     
     // MARK: - RTMP Service URL and Streaming key
     private let rtmp = "RTMP_SEVICE_URL"
-    private let key = "STREAMING_KEY"
+    private let streamKey = "STREAMING_KEY"
     
     override func broadcastStarted(withSetupInfo setupInfo: [String: NSObject]?) {
         Task {
@@ -25,8 +25,12 @@ final class SampleHandler: RPBroadcastSampleHandler {
             
             await stream.setVideoSettings(videoSettings)
             await mixer.addOutput(stream)
-            _ = try await connection.connect(rtmp)
-            _ = try await stream.publish(key)
+            
+            guard let rtmpURL = sharedDefaults.string(forKey: rtmp),
+                  let streamKey = sharedDefaults.string(forKey: streamKey) else { return }
+            
+            _ = try await connection.connect(rtmpURL)
+            _ = try await stream.publish(streamKey)
         }
         
         sharedDefaults.set(true, forKey: self.isStreamingKey)

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
@@ -46,6 +46,8 @@ public class BroadcastCollectionViewModel: ViewModel {
     
     let sharedDefaults = UserDefaults(suiteName: "group.kr.codesquad.boostcamp9.Shook")!
     let isStreamingKey = "isStreaming"
+    private let rtmp = "RTMP_SEVICE_URL"
+    private let streamKey = "STREAMING_KEY"
     let extensionBundleID = "kr.codesquad.boostcamp9.Shook.BroadcastUploadExtension"
     
     private var channelName: String = ""
@@ -107,8 +109,11 @@ public class BroadcastCollectionViewModel: ViewModel {
                     .eraseToAnyPublisher()
             }
             .sink { _ in
-            } receiveValue: { [weak self] (channelInfo) in
-                self?.output.isReadyToStream.send(true)
+            } receiveValue: { [weak self] (channelInfo, _) in
+                guard let self else { return }
+                sharedDefaults.set(channelInfo.rtmpUrl, forKey: rtmp)
+                sharedDefaults.set(channelInfo.streamKey, forKey: streamKey)
+                output.isReadyToStream.send(true)
             }
             .store(in: &cancellables)
 


### PR DESCRIPTION
## 💡 요약 및 이슈 

### App과 Extension과 RTMP URL 및 StreamKey 공유

- Resolves: #252

## 📃 작업내용

### UserDefaults를 통해 App과 Extension과 RTMP URL 및 StreamKey 공유

- 채널 생성 및 방송 송출 테스트

채널 생성 후 방송 송출까지 테스트 완료했습니다.

## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
