### PR TITLE
task #255 채널삭제 usecase 구현

### DIFF
--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+import BroadcastDomain
+import BroadcastDomainInterface
 import ChattingDomain
 import ChattingDomainInterface
 import LiveStationDomain
@@ -51,6 +53,9 @@ extension SceneDelegate {
         
         let createChannelUsecaseImpl = CreateChannelUsecaseImpl(repository: liveStationRepository)
         DIContainer.shared.register(CreateChannelUsecase.self, dependency: createChannelUsecaseImpl)
+        
+        let deleteChannelUsecaseImpl = DeleteChannelUsecaseImpl(repository: liveStationRepository)
+        DIContainer.shared.register(DeleteChannelUsecase.self, dependency: deleteChannelUsecaseImpl)
         
         let fetchChannelInfoUsecaseImpl = FetchChannelInfoUsecaseImpl(repository: liveStationRepository)
         DIContainer.shared.register(FetchChannelInfoUsecase.self, dependency: fetchChannelInfoUsecaseImpl)

--- a/Projects/App/Sources/Splash/SplashViewController.swift
+++ b/Projects/App/Sources/Splash/SplashViewController.swift
@@ -98,12 +98,14 @@ extension SplashViewController {
     private func moveToMainView() {
         let fetchChannelListUsecase = DIContainer.shared.resolve(FetchChannelListUsecase.self)
         let createChannelUsecase = DIContainer.shared.resolve(CreateChannelUsecase.self)
+        let deleteChannelUsecase = DIContainer.shared.resolve(DeleteChannelUsecase.self)
         let fetchChannelInfoUsecase = DIContainer.shared.resolve(FetchChannelInfoUsecase.self)
         let makeChatRoomUsecase = DIContainer.shared.resolve(MakeChatRoomUseCase.self)
         let factory = DIContainer.shared.resolve(LiveStreamViewControllerFactory.self)
         let viewModel = BroadcastCollectionViewModel(
             fetchChannelListUsecase: fetchChannelListUsecase,
             createChannelUsecase: createChannelUsecase,
+            deleteChannelUsecase: deleteChannelUsecase,
             fetchChannelInfoUsecase: fetchChannelInfoUsecase,
             makeChatRoomUsecase: makeChatRoomUsecase
         )

--- a/Projects/Domains/LiveStationDomain/Interface/UseCase/DeleteChannelUsecase.swift
+++ b/Projects/Domains/LiveStationDomain/Interface/UseCase/DeleteChannelUsecase.swift
@@ -1,0 +1,5 @@
+import Combine
+
+public protocol DeleteChannelUsecase {
+    func execute(channelID: String) -> AnyPublisher<Void, Error>
+}

--- a/Projects/Domains/LiveStationDomain/Sources/UseCase/DeleteChannelUsecaseImpl.swift
+++ b/Projects/Domains/LiveStationDomain/Sources/UseCase/DeleteChannelUsecaseImpl.swift
@@ -1,0 +1,17 @@
+import Combine
+
+import LiveStationDomainInterface
+
+public struct DeleteChannelUsecaseImpl: DeleteChannelUsecase {
+    private let repository: LiveStationRepository
+    
+    public init(repository: LiveStationRepository) {
+        self.repository = repository
+    }
+    
+    public func execute(channelID: String) -> AnyPublisher<Void, any Error> {
+        repository.deleteChannel(id: channelID)
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Projects/Features/MainFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/MainFeature/Demo/Sources/AppDelegate.swift
@@ -14,11 +14,13 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
         let mockFetchChannelListUsecase = MockFetchChannelListUsecaseImpl()
         let mockCreateChannelUsecase = MockCreateChannelUsecaseImpl()
+        let mockDeleteChannelUsecase = MockDeleteChannelUsecaseImpl()
         let mockFetchChannelInfoUsecase = MockFetchChannelInfoUsecaseImpl()
         let mockMakeChatRoomUseCase = MockMakeChatRoomUseCaseImpl()
         let viewModel = BroadcastCollectionViewModel(
             fetchChannelListUsecase: mockFetchChannelListUsecase,
             createChannelUsecase: mockCreateChannelUsecase,
+            deleteChannelUsecase: mockDeleteChannelUsecase,
             fetchChannelInfoUsecase: mockFetchChannelInfoUsecase,
             makeChatRoomUsecase: mockMakeChatRoomUseCase
         )

--- a/Projects/Features/MainFeature/Demo/Sources/MockDeleteChannelUsecaseImpl.swift
+++ b/Projects/Features/MainFeature/Demo/Sources/MockDeleteChannelUsecaseImpl.swift
@@ -1,0 +1,11 @@
+import Combine
+
+import LiveStationDomainInterface
+
+final class MockDeleteChannelUsecaseImpl: DeleteChannelUsecase {
+    func execute(channelID: String) -> AnyPublisher<Void, any Error> {
+        Future { promise in
+            promise(.success(()))
+        }.eraseToAnyPublisher()
+    }
+}

--- a/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastCollectionViewModel.swift
@@ -22,7 +22,7 @@ public class BroadcastCollectionViewModel: ViewModel {
         let fetch: PassthroughSubject<Void, Never> = .init()
         let didWriteStreamingName: PassthroughSubject<String, Never> = .init()
         let didTapBroadcastButton: PassthroughSubject<Void, Never> = .init()
-        let didTapEndStreamingButton: PassthroughSubject<Void, Never> = .init()
+        let didTapFinishStreamingButton: PassthroughSubject<Void, Never> = .init()
         let didTapStartBroadcastButton: PassthroughSubject<Void, Never> = .init()
     }
     
@@ -39,6 +39,7 @@ public class BroadcastCollectionViewModel: ViewModel {
     
     private let fetchChannelListUsecase: any FetchChannelListUsecase
     private let createChannelUsecase: any CreateChannelUsecase
+    private let deleteChannelUsecase: any DeleteChannelUsecase
     private let fetchChannelInfoUsecase: any FetchChannelInfoUsecase
     private let makeChatRoomUsecase: any MakeChatRoomUseCase
     
@@ -49,15 +50,18 @@ public class BroadcastCollectionViewModel: ViewModel {
     let extensionBundleID = "kr.codesquad.boostcamp9.Shook.BroadcastUploadExtension"
     
     private var channelName: String = ""
+    private var channel: ChannelEntity?
 
     public init(
         fetchChannelListUsecase: FetchChannelListUsecase,
         createChannelUsecase: CreateChannelUsecase,
+        deleteChannelUsecase: DeleteChannelUsecase,
         fetchChannelInfoUsecase: FetchChannelInfoUsecase,
         makeChatRoomUsecase: MakeChatRoomUseCase
     ) {
         self.fetchChannelListUsecase = fetchChannelListUsecase
         self.createChannelUsecase = createChannelUsecase
+        self.deleteChannelUsecase = deleteChannelUsecase
         self.fetchChannelInfoUsecase = fetchChannelInfoUsecase
         self.makeChatRoomUsecase = makeChatRoomUsecase
     }
@@ -87,8 +91,14 @@ public class BroadcastCollectionViewModel: ViewModel {
             }
             .store(in: &cancellables)
         
-        input.didTapEndStreamingButton
-            .sink { [weak self] _ in
+        input.didTapFinishStreamingButton
+            .flatMap { [weak self] _ in
+                guard let self, let channel else { return Empty<Void, Error>().eraseToAnyPublisher() }
+                return deleteChannelUsecase.execute(channelID: channel.id)
+                    .eraseToAnyPublisher()
+            }
+            .sink { _ in
+            } receiveValue: { [weak self] _ in
                 self?.output.dismissBroadcastUIView.send()
             }
             .store(in: &cancellables)

--- a/Projects/Features/MainFeature/Sources/BroadcastUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/BroadcastUIViewController.swift
@@ -103,6 +103,6 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
     
     private func didFinishBroadCast() {
         dismiss(animated: false)
-        viewModelInput.didTapEndStreamingButton.send()
+        viewModelInput.didTapFinishStreamingButton.send()
     }
 }


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 채널 삭제하는 usecase를 구현하고 viewmodel과 연결했습니다.

- Resolves: #255

## 📃 작업내용

- usecase 구현
- viewmodel과 연결

## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
