### PR TITLE
task network 모듈 테스트 형식을 URLSessionConfiguration을 이용하도록 합니다.

### DIFF
--- a/Projects/Modules/NetworkModule/Tests/NetworkClientTest.swift
+++ b/Projects/Modules/NetworkModule/Tests/NetworkClientTest.swift
@@ -9,14 +9,15 @@ final class NetworkClientTest: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        URLProtocol.registerClass(MockURLProtocol.self)
         interceptors = [DefaultLoggingInterceptor()]
-        client = NetworkClient(interceptors: interceptors)
+        let configuration = URLSessionConfiguration.ephemeral // 일시적인
+        configuration.protocolClasses = [MockURLProtocol.self] // URLProtocol subclasses 등록
+        let session = URLSession(configuration: configuration)
+        client = NetworkClient(session: session, interceptors: interceptors)
     }
     
     override func tearDown() {
         super.tearDown()
-        URLProtocol.unregisterClass(MockURLProtocol.self)
     }
 
     // MARK: - Success


### PR DESCRIPTION
## 💡 요약 및 이슈 

### static 변수로 URLProtocol subclass를 등록하거나 제거했습니다.

## 📃 작업내용

### subclass 등록을 configuration에서 합니다.

## 🙋‍♂️ 리뷰노트

없습니다.

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
