### PR TITLE
task #273 채널 생성 및 삭제 시점 변경

### DIFF
--- a/Projects/App/Sources/Splash/SplashViewController.swift
+++ b/Projects/App/Sources/Splash/SplashViewController.swift
@@ -48,8 +48,6 @@ public final class SplashViewController: BaseViewController<EmptyViewModel> {
 extension SplashViewController {
     private func moveToMainView() {
         let fetchChannelListUsecase = DIContainer.shared.resolve(FetchChannelListUsecase.self)
-        let createChannelUsecase = DIContainer.shared.resolve(CreateChannelUsecase.self)
-        let deleteChannelUsecase = DIContainer.shared.resolve(DeleteChannelUsecase.self)
         let fetchChannelInfoUsecase = DIContainer.shared.resolve(FetchChannelInfoUsecase.self)
         let makeBroadcastUsecase = DIContainer.shared.resolve(MakeBroadcastUsecase.self)
         let fetchAllBroadcastUsecase = DIContainer.shared.resolve(FetchAllBroadcastUsecase.self)
@@ -57,8 +55,6 @@ extension SplashViewController {
         let factory = DIContainer.shared.resolve(LiveStreamViewControllerFactory.self)
         let viewModel = BroadcastCollectionViewModel(
             fetchChannelListUsecase: fetchChannelListUsecase,
-            createChannelUsecase: createChannelUsecase,
-            deleteChannelUsecase: deleteChannelUsecase,
             fetchChannelInfoUsecase: fetchChannelInfoUsecase,
             makeBroadcastUsecase: makeBroadcastUsecase,
             fetchAllBroadcastUsecase: fetchAllBroadcastUsecase,
@@ -66,10 +62,11 @@ extension SplashViewController {
         )
         let viewController = BroadcastCollectionViewController(viewModel: viewModel, factory: factory)
         let navigationController = UINavigationController(rootViewController: viewController)
-        
+        let createChannelUsecase = DIContainer.shared.resolve(CreateChannelUsecase.self)
+
         /// 유저의 이름이 저장되어 있지 않으면 유저 등록 뷰를 Navigation에 올림
         if UserDefaults.standard.string(forKey: "USER_NAME") == nil {
-            let singUpViewModel = SignUpViewModel()
+            let singUpViewModel = SignUpViewModel(createChannelUsecase: createChannelUsecase)
             navigationController.viewControllers.append(SignUpViewController(viewModel: singUpViewModel))
         }
         

--- a/Projects/Features/AuthFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/AuthFeature/Demo/Sources/AppDelegate.swift
@@ -11,7 +11,8 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
-        let viewModel = SignUpViewModel()
+        let mockCreateChannelUsecase = MockCreateChannelUsecaseImpl()
+        let viewModel = SignUpViewModel(createChannelUsecase: mockCreateChannelUsecase)
         let viewController = SignUpViewController(viewModel: viewModel)
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()

--- a/Projects/Features/AuthFeature/Demo/Sources/MockCreateChannelUsecaseImpl.swift
+++ b/Projects/Features/AuthFeature/Demo/Sources/MockCreateChannelUsecaseImpl.swift
@@ -1,0 +1,11 @@
+import Combine
+
+import LiveStationDomainInterface
+
+final class MockCreateChannelUsecaseImpl: CreateChannelUsecase {
+    func execute(name: String) -> AnyPublisher<ChannelEntity, any Error> {
+        Future { promise in
+            promise(.success(ChannelEntity(id: "", name: name)))
+        }.eraseToAnyPublisher()
+    }
+}

--- a/Projects/Features/AuthFeature/Sources/SignUpViewController.swift
+++ b/Projects/Features/AuthFeature/Sources/SignUpViewController.swift
@@ -62,6 +62,7 @@ public class SignUpViewController: BaseViewController<SignUpViewModel> {
             .store(in: &cancellables)
         
         output.isSaved
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] isSaved in
                 if isSaved {
                     self?.textField.resignFirstResponder()

--- a/Projects/Features/AuthFeature/Sources/SignUpViewController.swift
+++ b/Projects/Features/AuthFeature/Sources/SignUpViewController.swift
@@ -25,7 +25,7 @@ public class SignUpViewController: BaseViewController<SignUpViewModel> {
     
     private let confettiAnimationView = LottieAnimationView(name: "confetti", bundle: Bundle(for: DesignSystemResources.self))
     private let shookAnimationView = LottieAnimationView(name: "shook", bundle: Bundle(for: DesignSystemResources.self))
-    private lazy var loadingView = SHLoadingView(message: "아이디 등록 중")
+    private lazy var loadingView = SHLoadingView(message: "닉네임 등록 중")
     
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)

--- a/Projects/Features/MainFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/MainFeature/Demo/Sources/AppDelegate.swift
@@ -13,16 +13,12 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         let mockFetchChannelListUsecase = MockFetchChannelListUsecaseImpl()
-        let mockCreateChannelUsecase = MockCreateChannelUsecaseImpl()
-        let mockDeleteChannelUsecase = MockDeleteChannelUsecaseImpl()
         let mockFetchChannelInfoUsecase = MockFetchChannelInfoUsecaseImpl()
         let mockmakeBroadcastUsecase = MockMakeBroadcastUsecaseImpl()
         let mockFetchAllBroadcastUsecase = MockFetchAllBroadcastUsecaseImpl()
         let mockDeleteBroadcastUsecase = MockDeleteBroadcastUsecaseImpl()
         let viewModel = BroadcastCollectionViewModel(
             fetchChannelListUsecase: mockFetchChannelListUsecase,
-            createChannelUsecase: mockCreateChannelUsecase,
-            deleteChannelUsecase: mockDeleteChannelUsecase,
             fetchChannelInfoUsecase: mockFetchChannelInfoUsecase,
             makeBroadcastUsecase: mockmakeBroadcastUsecase,
             fetchAllBroadcastUsecase: mockFetchAllBroadcastUsecase,
@@ -37,5 +33,3 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
-
-

--- a/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastUIViewController.swift
@@ -100,7 +100,8 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
     }
     
     private func didFinishBroadCast() {
-        dismiss(animated: false)
-        viewModelInput.didTapFinishStreamingButton.send()
+        dismiss(animated: false) { [weak self] in
+            self?.viewModelInput.didTapFinishStreamingButton.send()
+        }
     }
 }

--- a/Projects/Features/MainFeature/Sources/ViewControllers/SettingUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/SettingUIViewController.swift
@@ -17,7 +17,7 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
     private let streamingDescriptionCell = SettingTableViewCell(style: .default, reuseIdentifier: nil)
     private let streamingNameCell = SettingTableViewCell(style: .default, reuseIdentifier: nil)
     private let placeholderStringOfCells = ["어떤 방송인지 알려주세요!", "방송 내용을 알려주세요!"]
-    private lazy var loadingView = SHLoadingView(message: "채널 생성 중")
+    private lazy var loadingView = SHLoadingView(message: "방송 생성 중")
     
     private var broadcastPicker = RPSystemBroadcastPickerView()
     

--- a/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
@@ -120,16 +120,12 @@ public class BroadcastCollectionViewModel: ViewModel {
             .store(in: &cancellables)
         
         input.didTapStartBroadcastButton
-            .flatMap { [weak self] _ in
-                guard let self else { return Empty<ChannelEntity, Error>().eraseToAnyPublisher() }
-                output.isReadyToStream.send(false)
-                return createChannelUsecase.execute(name: channelName)
-            }
             .flatMap { [weak self] in
-                guard let self else { return Empty<ChannelInfoEntity, Error>().eraseToAnyPublisher() }
-                channel = $0
-                return fetchChannelInfoUsecase.execute(channelID: $0.id)
-                    .zip(makeBroadcastUsecase.execute(id: $0.id, title: $0.name, owner: userName, description: channelDescription))
+                guard let self,
+                      let channelID else { return Empty<ChannelInfoEntity, Error>().eraseToAnyPublisher() }
+                output.isReadyToStream.send(false)
+                return fetchChannelInfoUsecase.execute(channelID: channelID)
+                    .zip(makeBroadcastUsecase.execute(id: channelID, title: broadcastName, owner: userName, description: channelDescription))
                     .map { channelInfo, _ in channelInfo }
                     .eraseToAnyPublisher()
             }

--- a/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
@@ -181,15 +181,10 @@ public class BroadcastCollectionViewModel: ViewModel {
     /// - Parameter _:  방송 이름
     /// - Returns: (Bool, String?) - 유효 여부와 에러 메시지
     private func valid(_ value: String) -> (isValid: Bool, errorMessage: String?) {
-        let isLengthValid = 3...20 ~= value.count
-        let isCharactersValid = value.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+        let trimmedValue = value.trimmingCharacters(in: .whitespaces)
         
-        if !isLengthValid && !isCharactersValid {
-            return (false, "3글자 이상,20글자 이하로 입력해 주세요. 특수문자는 언더바(_)만 가능합니다.")
-        } else if !isLengthValid {
-            return (false, "최소 3글자 이상, 최대 20글자 이하로 입력해 주세요.")
-        } else if !isCharactersValid {
-            return (false, "특수문자는 언더바(_)만 가능합니다.")
+        if trimmedValue.isEmpty {
+            return (false, "공백을 제외하고 최소 1글자 이상 입력해주세요.")
         } else {
             return (true, nil)
         }

--- a/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
@@ -158,7 +158,7 @@ public class BroadcastCollectionViewModel: ViewModel {
                     let broadcast = broadcastInfoEntities.first { $0.id == channelEntity.id }
                     return Channel(
                         id: channelEntity.id,
-                        title: channelEntity.name,
+                        title: broadcast?.title ?? "Unknown",
                         thumbnailImageURLString: channelEntity.imageURLString,
                         owner: broadcast?.owner ?? "Unknown",
                         description: broadcast?.description ?? ""

--- a/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
@@ -43,8 +43,6 @@ public class BroadcastCollectionViewModel: ViewModel {
     private let output = Output()
     
     private let fetchChannelListUsecase: any FetchChannelListUsecase
-    private let createChannelUsecase: any CreateChannelUsecase
-    private let deleteChannelUsecase: any DeleteChannelUsecase
     private let fetchChannelInfoUsecase: any FetchChannelInfoUsecase
     private let makeBroadcastUsecase: any MakeBroadcastUsecase
     private let fetchAllBroadcastUsecase: any FetchAllBroadcastUsecase
@@ -59,22 +57,18 @@ public class BroadcastCollectionViewModel: ViewModel {
     let extensionBundleID = "kr.codesquad.boostcamp9.Shook.BroadcastUploadExtension"
     
     private let userName = UserDefaults.standard.string(forKey: "USER_NAME") ?? ""
-    private var channelName: String = ""
+    private var broadcastName: String = ""
     private var channelDescription: String = ""
-    private var channel: ChannelEntity?
+    private var channelID = UserDefaults.standard.string(forKey: "CHANNEL_ID")
 
     public init(
         fetchChannelListUsecase: FetchChannelListUsecase,
-        createChannelUsecase: CreateChannelUsecase,
-        deleteChannelUsecase: DeleteChannelUsecase,
         fetchChannelInfoUsecase: FetchChannelInfoUsecase,
         makeBroadcastUsecase: MakeBroadcastUsecase,
         fetchAllBroadcastUsecase: FetchAllBroadcastUsecase,
         deleteBroadCastUsecase: DeleteBroadcastUsecase
     ) {
         self.fetchChannelListUsecase = fetchChannelListUsecase
-        self.createChannelUsecase = createChannelUsecase
-        self.deleteChannelUsecase = deleteChannelUsecase
         self.fetchChannelInfoUsecase = fetchChannelInfoUsecase
         self.makeBroadcastUsecase = makeBroadcastUsecase
         self.fetchAllBroadcastUsecase = fetchAllBroadcastUsecase
@@ -95,7 +89,7 @@ public class BroadcastCollectionViewModel: ViewModel {
                 self.output.streamingStartButtonIsActive.send(validness.isValid)
                 self.output.errorMessage.send(validness.errorMessage)
                 if validness.isValid {
-                    channelName = name
+                    broadcastName = name
                 }
             }
             .store(in: &cancellables)
@@ -114,9 +108,9 @@ public class BroadcastCollectionViewModel: ViewModel {
         
         input.didTapFinishStreamingButton
             .flatMap { [weak self] _ in
-                guard let self, let channel else { return Empty<(Void, Void), Error>().eraseToAnyPublisher() }
-                return deleteChannelUsecase.execute(channelID: channel.id)
-                    .zip(deleteBroadCastUsecase.execute(id: channel.id))
+                guard let self,
+                      let channelID else { return Empty<Void, Error>().eraseToAnyPublisher() }
+                return deleteBroadCastUsecase.execute(id: channelID)
                     .eraseToAnyPublisher()
             }
             .sink { _ in


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 채널 생성 및 삭제 시점을 변경했습니다.

- Resolves: #273 

## 📃 작업내용

- 채널 생성 시점 변경
- 채널 삭제 지우기
- 유효성검사 로직 수정
- cell 리스트에서 이름 변경

## 🙋‍♂️ 리뷰노트

1. 닉네임 유효성검사가 끝나고 UserDefaults에 저장하는 메소드에서 채널 생성 유즈케이스를 실행해줬습니다.
```Swift
   private func save(for name: String?) {
        guard let name else { return }
        UserDefaults.standard.set(name, forKey: "USER_NAME")
        
        let savedName = UserDefaults.standard.string(forKey: "USER_NAME")
        
        createChannelUsecase.execute(name: "Guest")
            .sink { _ in
            } receiveValue: { [weak self] channelEntity in
                UserDefaults.standard.set(channelEntity.id, forKey: "CHANNEL_ID")
                let savedID = UserDefaults.standard.string(forKey: "CHANNEL_ID")
                
                self?.output.isSaved.send(savedName == name && savedID != nil)
            }
            .store(in: &cancellables)
    }
```
보통 Usecase를 실행하는 메소드를 따로 빼서 구현되어 있거나, input으로 스트림을 처리할 때 진행하던데 위와 같이하는게 좋을지 따로 메소드로 빼는게 좋을지 고민했습니다.
결과적으로 output으로 보낼 때 닉네임이 제대로 저장되었는지와 채널 id가 저장되었는지 2개를 확인해야했기에 하나의 메소드 안에 같이 있는게 좋을 것 같다고 판단했습니다.
보시기에 어떠신가요?


2. DeleteChannelUsecase는 혹시 몰라서 남겨뒀는데 삭제하는게 좋을까요?

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
