### PR TITLE
task #276 main feature viewmodel separation

### DIFF
--- a/Projects/App/BroadcastUploadExtension/Sources/SampleHandler.swift
+++ b/Projects/App/BroadcastUploadExtension/Sources/SampleHandler.swift
@@ -5,7 +5,7 @@ import HaishinKit
 final class SampleHandler: RPBroadcastSampleHandler {
     // MARK: - App group
     private let sharedDefaults = UserDefaults(suiteName: "group.kr.codesquad.boostcamp9.Shook")!
-    private let isStreamingKey = "isStreaming"
+    private let isStreamingKey = "IS_STREAMING"
     
     // MARK: - HaishinKit
     private let mixer = MediaMixer()

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -7,6 +7,7 @@ import LiveStationDomainInterface
 import LiveStreamFeature
 import LiveStreamFeatureInterface
 import MainFeature
+import MainFeatureInterface
 import ThirdPartyLibModule
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -55,13 +56,13 @@ extension SceneDelegate {
         let deleteChannelUsecaseImpl = DeleteChannelUsecaseImpl(repository: liveStationRepository)
         DIContainer.shared.register(DeleteChannelUsecase.self, dependency: deleteChannelUsecaseImpl)
         
-        let fetchChannelInfoUsecaseImpl = FetchChannelInfoUsecaseImpl(repository: liveStationRepository)
+        let fetchChannelInfoUsecaseImpl: any FetchChannelInfoUsecase = FetchChannelInfoUsecaseImpl(repository: liveStationRepository)
         DIContainer.shared.register(FetchChannelInfoUsecase.self, dependency: fetchChannelInfoUsecaseImpl)
         
         let broadcastRepository = BroadcastRepositoryImpl()
-        let makeBroadcastUsecaseImpl = MakeBroadcastUsecaseImpl(repository: broadcastRepository)
+        let makeBroadcastUsecaseImpl: any MakeBroadcastUsecase = MakeBroadcastUsecaseImpl(repository: broadcastRepository)
         let fetchAllBroadcastUsecaseImpl = FetchAllBroadcastUsecaseImpl(repository: broadcastRepository)
-        let deleteBroadCastUsecaseImpl = DeleteBroadcastUsecaseImpl(repository: broadcastRepository)
+        let deleteBroadCastUsecaseImpl: DeleteBroadcastUsecase = DeleteBroadcastUsecaseImpl(repository: broadcastRepository)
         DIContainer.shared.register(MakeBroadcastUsecase.self, dependency: makeBroadcastUsecaseImpl)
         DIContainer.shared.register(FetchAllBroadcastUsecase.self, dependency: fetchAllBroadcastUsecaseImpl)
         DIContainer.shared.register(DeleteBroadcastUsecase.self, dependency: deleteBroadCastUsecaseImpl)
@@ -69,5 +70,19 @@ extension SceneDelegate {
         let fetchBroadcastUseCase: any FetchVideoListUsecase = FetchVideoListUsecaseImpl(repository: liveStationRepository)
         let liveStreamFactoryImpl = LiveStreamViewControllerFactoryImpl(fetchBroadcastUseCase: fetchBroadcastUseCase)
         DIContainer.shared.register(LiveStreamViewControllerFactory.self, dependency: liveStreamFactoryImpl)
+        
+        let settingFactoryImpl = SettingViewControllerFactoryImpl(
+            fetchChannelInfoUsecase: fetchChannelInfoUsecaseImpl,
+            makeBroadcastUsecase: makeBroadcastUsecaseImpl,
+            deleteBroadCastUsecase: deleteBroadCastUsecaseImpl
+        )
+        DIContainer.shared.register(SettingViewControllerFactory.self, dependency: settingFactoryImpl)
+        
+        let broadcastViewControllerFactory = BroadcastViewControllerFactoryImpl(
+            fetchChannelInfoUsecase: fetchChannelInfoUsecaseImpl,
+            makeBroadcastUsecase: makeBroadcastUsecaseImpl,
+            deleteBroadCastUsecase: deleteBroadCastUsecaseImpl
+        )
+        DIContainer.shared.register(BroadcastViewControllerFactory.self, dependency: broadcastViewControllerFactory)
     }
 }

--- a/Projects/App/Sources/Splash/SplashViewController.swift
+++ b/Projects/App/Sources/Splash/SplashViewController.swift
@@ -11,6 +11,7 @@ import LiveStationDomainInterface
 import LiveStreamFeatureInterface
 import Lottie
 import MainFeature
+import MainFeatureInterface
 
 public final class SplashViewController: BaseViewController<EmptyViewModel> {
     private let splashGradientView = SplashGradientView()
@@ -48,19 +49,15 @@ public final class SplashViewController: BaseViewController<EmptyViewModel> {
 extension SplashViewController {
     private func moveToMainView() {
         let fetchChannelListUsecase = DIContainer.shared.resolve(FetchChannelListUsecase.self)
-        let fetchChannelInfoUsecase = DIContainer.shared.resolve(FetchChannelInfoUsecase.self)
-        let makeBroadcastUsecase = DIContainer.shared.resolve(MakeBroadcastUsecase.self)
         let fetchAllBroadcastUsecase = DIContainer.shared.resolve(FetchAllBroadcastUsecase.self)
-        let deleteBroadCastUsecase = DIContainer.shared.resolve(DeleteBroadcastUsecase.self)
         let factory = DIContainer.shared.resolve(LiveStreamViewControllerFactory.self)
+        let settingFactory = DIContainer.shared.resolve(SettingViewControllerFactory.self)
+        let broadcastFactory = DIContainer.shared.resolve(BroadcastViewControllerFactory.self)
         let viewModel = BroadcastCollectionViewModel(
             fetchChannelListUsecase: fetchChannelListUsecase,
-            fetchChannelInfoUsecase: fetchChannelInfoUsecase,
-            makeBroadcastUsecase: makeBroadcastUsecase,
-            fetchAllBroadcastUsecase: fetchAllBroadcastUsecase,
-            deleteBroadCastUsecase: deleteBroadCastUsecase
+            fetchAllBroadcastUsecase: fetchAllBroadcastUsecase
         )
-        let viewController = BroadcastCollectionViewController(viewModel: viewModel, factory: factory)
+        let viewController = BroadcastCollectionViewController(viewModel: viewModel, factory: factory, settingFactory: settingFactory, broadcastFactory: broadcastFactory)
         let navigationController = UINavigationController(rootViewController: viewController)
         let createChannelUsecase = DIContainer.shared.resolve(CreateChannelUsecase.self)
 

--- a/Projects/Features/MainFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/MainFeature/Demo/Sources/AppDelegate.swift
@@ -19,10 +19,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         let mockDeleteBroadcastUsecase = MockDeleteBroadcastUsecaseImpl()
         let viewModel = BroadcastCollectionViewModel(
             fetchChannelListUsecase: mockFetchChannelListUsecase,
-            fetchChannelInfoUsecase: mockFetchChannelInfoUsecase,
-            makeBroadcastUsecase: mockmakeBroadcastUsecase,
-            fetchAllBroadcastUsecase: mockFetchAllBroadcastUsecase,
-            deleteBroadCastUsecase: mockDeleteBroadcastUsecase
+            fetchAllBroadcastUsecase: mockFetchAllBroadcastUsecase
         )
         let mockFactory = MockLiveStreamViewControllerFractoryImpl()
         let viewController = BroadcastCollectionViewController(viewModel: viewModel, factory: mockFactory)

--- a/Projects/Features/MainFeature/Interface/BroadcastViewControllerFactory.swift
+++ b/Projects/Features/MainFeature/Interface/BroadcastViewControllerFactory.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+public protocol BroadcastViewControllerFactory {
+    func make() -> UIViewController
+}

--- a/Projects/Features/MainFeature/Interface/SettingViewControllerFactory.swift
+++ b/Projects/Features/MainFeature/Interface/SettingViewControllerFactory.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+public protocol SettingViewControllerFactory {
+    func make() -> UIViewController
+}

--- a/Projects/Features/MainFeature/Project.swift
+++ b/Projects/Features/MainFeature/Project.swift
@@ -6,7 +6,9 @@ import EnvironmentPlugin
 let project = Project.module(
     name: ModulePaths.Feature.MainFeature.rawValue,
     targets: [
+        .interface(module: .feature(.MainFeature)),
         .implements(module: .feature(.MainFeature), dependencies: [
+            .feature(target: .MainFeature, type: .interface),
             .feature(target: .BaseFeature),
             .feature(target: .LiveStreamFeature, type: .interface),
             .domain(target: .LiveStationDomain, type: .interface),

--- a/Projects/Features/MainFeature/Sources/Factory/BroadcastViewControllerFactoryImpl.swift
+++ b/Projects/Features/MainFeature/Sources/Factory/BroadcastViewControllerFactoryImpl.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+import BroadcastDomainInterface
+import LiveStationDomainInterface
+import MainFeatureInterface
+
+public struct BroadcastViewControllerFactoryImpl: BroadcastViewControllerFactory {
+    private let fetchChannelInfoUsecase: any FetchChannelInfoUsecase
+    private let makeBroadcastUsecase: any MakeBroadcastUsecase
+    private let deleteBroadCastUsecase: any DeleteBroadcastUsecase
+    
+    public init(fetchChannelInfoUsecase: any FetchChannelInfoUsecase, makeBroadcastUsecase: any MakeBroadcastUsecase, deleteBroadCastUsecase: any DeleteBroadcastUsecase) {
+        self.fetchChannelInfoUsecase = fetchChannelInfoUsecase
+        self.makeBroadcastUsecase = makeBroadcastUsecase
+        self.deleteBroadCastUsecase = deleteBroadCastUsecase
+    }
+    
+    public func make() -> UIViewController {
+        let viewModel = SettingViewModel(
+            fetchChannelInfoUsecase: fetchChannelInfoUsecase,
+            makeBroadcastUsecase: makeBroadcastUsecase,
+            deleteBroadCastUsecase: deleteBroadCastUsecase
+        )
+        
+        return BroadcastViewController(viewModel: viewModel)
+    }
+}

--- a/Projects/Features/MainFeature/Sources/Factory/SettingViewControllerFactoryImpl.swift
+++ b/Projects/Features/MainFeature/Sources/Factory/SettingViewControllerFactoryImpl.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+import BroadcastDomainInterface
+import LiveStationDomainInterface
+import MainFeatureInterface
+
+public struct SettingViewControllerFactoryImpl: SettingViewControllerFactory {
+    private let fetchChannelInfoUsecase: any FetchChannelInfoUsecase
+    private let makeBroadcastUsecase: any MakeBroadcastUsecase
+    private let deleteBroadCastUsecase: any DeleteBroadcastUsecase
+    
+    public init(fetchChannelInfoUsecase: any FetchChannelInfoUsecase, makeBroadcastUsecase: any MakeBroadcastUsecase, deleteBroadCastUsecase: any DeleteBroadcastUsecase) {
+        self.fetchChannelInfoUsecase = fetchChannelInfoUsecase
+        self.makeBroadcastUsecase = makeBroadcastUsecase
+        self.deleteBroadCastUsecase = deleteBroadCastUsecase
+    }
+    
+    public func make() -> UIViewController {
+        let viewModel = SettingViewModel(
+            fetchChannelInfoUsecase: fetchChannelInfoUsecase,
+            makeBroadcastUsecase: makeBroadcastUsecase,
+            deleteBroadCastUsecase: deleteBroadCastUsecase
+        )
+        
+        return SettingUIViewController(viewModel: viewModel)
+    }
+}

--- a/Projects/Features/MainFeature/Sources/Utilities/BroadcastState.swift
+++ b/Projects/Features/MainFeature/Sources/Utilities/BroadcastState.swift
@@ -1,0 +1,7 @@
+import Combine
+
+final class BroadcastState {
+    static let shared = BroadcastState()
+    
+    let isBroadcasting: PassthroughSubject<Bool, Never> = .init()
+}

--- a/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastViewController.swift
@@ -6,9 +6,9 @@ import BaseFeature
 import BaseFeatureInterface
 import DesignSystem
 
-public final class BroadcastUIViewController: BaseViewController<BroadcastCollectionViewModel> {
+public final class BroadcastViewController: BaseViewController<SettingViewModel> {
     deinit {
-        viewModel.sharedDefaults.removeObserver(self, forKeyPath: viewModel.isStreamingKey)
+        viewModel.sharedDefaults?.removeObserver(self, forKeyPath: viewModel.isStreamingKey)
     }
     
     private let broadcastStatusStackView = UIStackView()
@@ -16,7 +16,7 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
     private let broadcastStateText = UILabel()
     private let endBroadcastButton = UIButton()
     
-    private let viewModelInput = BroadcastCollectionViewModel.Input()
+    private let viewModelInput = SettingViewModel.Input()
     
     public override func setupBind() {
         _ = viewModel.transform(input: viewModelInput)
@@ -40,7 +40,7 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
         
         endBroadcastButton.addSubview(broadcastPicker)
         
-        viewModel.sharedDefaults.addObserver(self, forKeyPath: viewModel.isStreamingKey, options: [.initial, .new], context: nil)
+        viewModel.sharedDefaults?.addObserver(self, forKeyPath: viewModel.isStreamingKey, options: [.initial, .new], context: nil)
         
         broadcastStatusStackView.addArrangedSubview(broadcastStatusImageView)
         broadcastStatusStackView.addArrangedSubview(broadcastStateText)
@@ -100,8 +100,7 @@ public final class BroadcastUIViewController: BaseViewController<BroadcastCollec
     }
     
     private func didFinishBroadCast() {
-        dismiss(animated: false) { [weak self] in
-            self?.viewModelInput.didTapFinishStreamingButton.send()
-        }
+        viewModelInput.didTapFinishStreamingButton.send()
+        dismiss(animated: false)
     }
 }

--- a/Projects/Features/MainFeature/Sources/ViewControllers/SettingUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/SettingUIViewController.swift
@@ -6,9 +6,9 @@ import BaseFeature
 import DesignSystem
 import EasyLayoutModule
 
-public final class SettingUIViewController: BaseViewController<BroadcastCollectionViewModel> {
+public final class SettingUIViewController: BaseViewController<SettingViewModel> {
     deinit {
-        viewModel.sharedDefaults.removeObserver(self, forKeyPath: viewModel.isStreamingKey)
+        viewModel.sharedDefaults?.removeObserver(self, forKeyPath: viewModel.isStreamingKey)
     }
     
     private let settingTableView = UITableView()
@@ -21,7 +21,7 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
     
     private var broadcastPicker = RPSystemBroadcastPickerView()
     
-    private let viewModelInput = BroadcastCollectionViewModel.Input()
+    private let viewModelInput = SettingViewModel.Input()
     private var cancellables = Set<AnyCancellable>()
     
     public override func observeValue(
@@ -79,8 +79,8 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
         closeBarButton.image = DesignSystemAsset.Image.xmark24.image
         closeBarButton.tintColor = .gray
         
-        viewModel.sharedDefaults.addObserver(self, forKeyPath: viewModel.isStreamingKey, options: [.initial, .new], context: nil)
-        viewModel.sharedDefaults.set(false, forKey: viewModel.isStreamingKey)
+        viewModel.sharedDefaults?.addObserver(self, forKeyPath: viewModel.isStreamingKey, options: [.initial, .new], context: nil)
+        viewModel.sharedDefaults?.set(false, forKey: viewModel.isStreamingKey)
         
         navigationItem.title = "방송설정"
         navigationItem.rightBarButtonItem = closeBarButton
@@ -150,7 +150,7 @@ public final class SettingUIViewController: BaseViewController<BroadcastCollecti
     }
     
     private func didStartBroadCast() {
-        viewModelInput.didTapBroadcastButton.send()
+        BroadcastState.shared.isBroadcasting.send(true)
         dismiss(animated: true)
     }
     

--- a/Projects/Features/MainFeature/Sources/ViewModels/SettingViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/SettingViewModel.swift
@@ -1,0 +1,124 @@
+import Combine
+import Foundation
+
+import BaseFeatureInterface
+import BroadcastDomainInterface
+import LiveStationDomainInterface
+
+public class SettingViewModel: ViewModel {
+    public struct Input {
+        let didWriteStreamingName: PassthroughSubject<String, Never> = .init()
+        let didWriteStreamingDescription: PassthroughSubject<String, Never> = .init()
+        let didTapStartBroadcastButton: PassthroughSubject<Void, Never> = .init()
+        let didTapFinishStreamingButton: PassthroughSubject<Void, Never> = .init()
+    }
+    
+    public struct Output {
+        let streamingStartButtonIsActive: PassthroughSubject<Bool, Never> = .init()
+        let errorMessage: PassthroughSubject<String?, Never> = .init()
+        let isReadyToStream: PassthroughSubject<Bool, Never> = .init()
+    }
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    private let fetchChannelInfoUsecase: any FetchChannelInfoUsecase
+    private let makeBroadcastUsecase: any MakeBroadcastUsecase
+    private let deleteBroadCastUsecase: any DeleteBroadcastUsecase
+    
+    private var broadcastName: String = ""
+    private var channelDescription: String = ""
+    private var channelID = UserDefaults.standard.string(forKey: "CHANNEL_ID")
+    private let userName = UserDefaults.standard.string(forKey: "USER_NAME") ?? ""
+    private let rtmp = "RTMP_SEVICE_URL"
+    private let streamKey = "STREAMING_KEY"
+
+    let sharedDefaults = UserDefaults(suiteName: "group.kr.codesquad.boostcamp9.Shook")
+    let extensionBundleID = "kr.codesquad.boostcamp9.Shook.BroadcastUploadExtension"
+    let isStreamingKey = "IS_STREAMING"
+    
+    public init(
+        fetchChannelInfoUsecase: FetchChannelInfoUsecase,
+        makeBroadcastUsecase: MakeBroadcastUsecase,
+        deleteBroadCastUsecase: DeleteBroadcastUsecase
+    ) {
+        self.fetchChannelInfoUsecase = fetchChannelInfoUsecase
+        self.makeBroadcastUsecase = makeBroadcastUsecase
+        self.deleteBroadCastUsecase = deleteBroadCastUsecase
+    }
+    
+    public func transform(input: Input) -> Output {
+        let output = Output()
+        
+        input.didWriteStreamingName
+            .sink { [weak self] name in
+                guard let self else { return }
+                let validness = valid(name)
+                output.streamingStartButtonIsActive.send(validness.isValid)
+                output.errorMessage.send(validness.errorMessage)
+                if validness.isValid {
+                    broadcastName = name
+                }
+            }
+            .store(in: &cancellables)
+        
+        input.didWriteStreamingDescription
+            .sink { [weak self] description in
+                self?.channelDescription = description
+            }
+            .store(in: &cancellables)
+        
+        input.didTapStartBroadcastButton
+            .flatMap { [weak self] in
+                guard let self,
+                      let channelID else { return Empty<ChannelInfoEntity, Error>().eraseToAnyPublisher() }
+                output.isReadyToStream.send(false)
+                return fetchChannelInfoUsecase.execute(channelID: channelID)
+                    .zip(
+                        makeBroadcastUsecase.execute(
+                            id: channelID,
+                            title: broadcastName,
+                            owner: userName,
+                            description: channelDescription
+                        )
+                    )
+                    .map { channelInfo, _ in channelInfo }
+                    .eraseToAnyPublisher()
+            }
+            .sink { _ in
+            } receiveValue: { [weak self] channelInfo in
+                guard let self else { return }
+                sharedDefaults?.set(channelInfo.rtmpUrl, forKey: rtmp)
+                sharedDefaults?.set(channelInfo.streamKey, forKey: streamKey)
+                output.isReadyToStream.send(true)
+            }
+            .store(in: &cancellables)
+        
+        input.didTapFinishStreamingButton
+            .flatMap { [weak self] _ in
+                guard let self,
+                      let channelID else { return Empty<Void, Error>().eraseToAnyPublisher() }
+                return deleteBroadCastUsecase.execute(id: channelID)
+                    .eraseToAnyPublisher()
+            }
+            .sink { _ in
+            } receiveValue: { _ in
+                BroadcastState.shared.isBroadcasting.send(false)
+            }
+            .store(in: &cancellables)
+        
+        return output
+    }
+    
+    /// 방송 이름이 유효한지 확인하는 메서드
+    /// - Parameter _:  방송 이름
+    /// - Returns: (Bool, String?) - 유효 여부와 에러 메시지
+    private func valid(_ value: String) -> (isValid: Bool, errorMessage: String?) {
+        let trimmedValue = value.trimmingCharacters(in: .whitespaces)
+        
+        if trimmedValue.isEmpty {
+            return (false, "공백을 제외하고 최소 1글자 이상 입력해주세요.")
+        } else {
+            return (true, nil)
+        }
+    }
+}

--- a/Projects/Modules/ChatSoketModule/Sources/WebSocket.swift
+++ b/Projects/Modules/ChatSoketModule/Sources/WebSocket.swift
@@ -50,7 +50,6 @@ public final class WebSocket: NSObject {
     }
     
     public func closeWebSocket() {
-        self.webSocketTask = nil
         self.timer?.invalidate()
         self.onReceiveClosure = nil
         self.delegate = nil


### PR DESCRIPTION
## 💡 요약 및 이슈 

### main feature usecase를 분리했습니다.

- Resolves: #276 

## 📃 작업내용

- 기존에 main feature에 setting view controller가 하는일이 많이 없고, 컬렉션뷰와 밀접했기에 viewmodel을 하나로 합쳤습니다. 그러나 현재 main feature쪽 viewmodel이 너무 커져서 가독성이 현저하게 낮다고 판단하여 viewmodel을 다시 분리했습니다.
- usecase 분리
- 겹치는 코드 삭제

## 🙋‍♂️ 리뷰노트

- 사용자가 아래 화면에서 방송시작을 누를 때 `(컬렉션뷰컨트롤러)`와 `(세팅뷰컨트롤러)`가 모두 알아야했습니다.
<img width = "180" src="https://github.com/user-attachments/assets/1c77f478-905f-4d64-837b-d581c913dabf">

`컬렉션 뷰컨트롤러`에서 방송이 시작됨을 감지하면 실행하는 메소드
```Swift
 private func showBroadcastUIView() {
    }
```

`세팅 뷰컨트롤러`에서 방송이 시작됨을 감지하면 실행하는 메소드
```Swift
 private func didStartBroadCast() {
}
```

뷰모델이 분리되었기에 두 뷰컨트롤러에게 모두 알려줄 방법이 필요했습니다.
1. 기존에 사용했던 것처럼 옵저버를 사용해서 구독하고 있는 뷰컨트롤러에게 모두 알려주는 방법이 좋을지
```Swift
 public override func observeValue(
        forKeyPath keyPath: String?,
        of object: Any?,
        change: [NSKeyValueChangeKey: Any]?,
        context: UnsafeMutableRawPointer?
    ) {
        if keyPath == viewModel.isStreamingKey {
            if let newValue = change?[.newKey] as? Bool, newValue == true {
                didStartBroadCast()
            }
        } else {
            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
        }
    }
```

2. 매니저같은 역할을 하는 객체를 하나 두어서 하나만 옵저버를 등록해두고, 다른 뷰컨트롤러는 해당 스트림을 받는게 좋을지
```Swift
final class BroadcastState {
    static let shared = BroadcastState()
    
    let isBroadcasting: PassthroughSubject<Bool, Never> = .init()
}
```

```Swift
/// BroadcastCollectionViewModel 일부
 BroadcastState.shared.isBroadcasting
            .sink { [weak self] isBroadcasting in
                if isBroadcasting {
                    self?.output.showBroadcastUIView.send()
                } else {
                    self?.output.dismissBroadcastUIView.send()
                }
            }
            .store(in: &cancellables)
```

두가지 방법을 두고 고민했습니다.
결과적으로 2번을 사용했고 그 이유는 다음과 같습니다.
1. 1번 방법을 사용한 코드가 많아질 경우 2번보다 데이터 흐름을 파악하기 더 어려울 것이라 판단했습니다.

이 부분에 대해서 팀원분들의 의견이 궁금합니다! 🥹

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
