### PR TITLE
task 방송 중 화면, 채널 리스트 오류 수정

### DIFF
--- a/Projects/Features/MainFeature/Sources/Models/Channel.swift
+++ b/Projects/Features/MainFeature/Sources/Models/Channel.swift
@@ -1,0 +1,26 @@
+import UIKit
+
+public struct Channel: Hashable {
+    let id: String
+    let name: String
+    var thumbnailImageURLString: String
+    var thumbnailImage: UIImage?
+    let owner: String
+    let description: String
+
+    public init(
+        id: String,
+        title: String,
+        thumbnailImageURLString: String = "",
+        thumbnailImage: UIImage? = nil,
+        owner: String = "",
+        description: String = ""
+    ) {
+        self.id = id
+        self.name = title
+        self.thumbnailImageURLString = thumbnailImageURLString
+        self.thumbnailImage = thumbnailImage
+        self.owner = owner
+        self.description = description
+    }
+}

--- a/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastCollectionViewController.swift
@@ -121,8 +121,9 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
             .store(in: &cancellables)
         
         output.dismissBroadcastUIView
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.dismissBroadcastUIView()
+                self?.dismissBroadcastView()
             }
             .store(in: &cancellables)
     }
@@ -304,19 +305,16 @@ extension BroadcastCollectionViewController {
         broadcastViewController.didMove(toParent: self)
     }
     
-    private func dismissBroadcastUIView() {
-#warning("메인스레드 오류 해결")
-        DispatchQueue.main.async { [weak self] in
-            guard let broadcastViewController = self?.children.first(where: { $0 is BroadcastViewController }) else { return }
-            UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut], animations: {
-                broadcastViewController.view.alpha = 0 }, completion: { _ in
-                    broadcastViewController.willMove(toParent: nil)
-                    broadcastViewController.view.removeFromSuperview()
-                    broadcastViewController.removeFromParent()
-                }
-            )
-            self?.navigationController?.setNavigationBarHidden(false, animated: false)
-            self?.input.fetch.send()
-        }
+    private func dismissBroadcastView() {
+        guard let broadcastViewController = children.first(where: { $0 is BroadcastViewController }) else { return }
+        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseInOut], animations: {
+            broadcastViewController.view.alpha = 0 }, completion: { _ in
+                broadcastViewController.willMove(toParent: nil)
+                broadcastViewController.view.removeFromSuperview()
+                broadcastViewController.removeFromParent()
+            }
+        )
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        input.fetch.send()
     }
 }

--- a/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastViewController.swift
@@ -14,7 +14,7 @@ public final class BroadcastViewController: BaseViewController<SettingViewModel>
     private let broadcastStatusStackView = UIStackView()
     private let broadcastStatusImageView = UIImageView()
     private let broadcastStateText = UILabel()
-    private let endBroadcastButton = UIButton()
+    private let finshBroadcastButton = UIButton()
     
     private let viewModelInput = SettingViewModel.Input()
     
@@ -38,7 +38,7 @@ public final class BroadcastViewController: BaseViewController<SettingViewModel>
         broadcastPicker.frame = CGRect(x: 0, y: 0, width: 0, height: 0)
         broadcastPicker.preferredExtension = viewModel.extensionBundleID
         
-        endBroadcastButton.addSubview(broadcastPicker)
+        finshBroadcastButton.addSubview(broadcastPicker)
         
         viewModel.sharedDefaults?.addObserver(self, forKeyPath: viewModel.isStreamingKey, options: [.initial, .new], context: nil)
         
@@ -46,7 +46,7 @@ public final class BroadcastViewController: BaseViewController<SettingViewModel>
         broadcastStatusStackView.addArrangedSubview(broadcastStateText)
         
         view.addSubview(broadcastStatusStackView)
-        view.addSubview(endBroadcastButton)
+        view.addSubview(finshBroadcastButton)
     }
     
     public override func setupStyles() {
@@ -60,11 +60,11 @@ public final class BroadcastViewController: BaseViewController<SettingViewModel>
         broadcastStateText.font = .setFont(.title())
         broadcastStateText.textColor = .white
 
-        endBroadcastButton.setTitle("방송종료", for: .normal)
-        endBroadcastButton.layer.cornerRadius = 16
-        endBroadcastButton.titleLabel?.font = .setFont(.body1())
-        endBroadcastButton.backgroundColor = DesignSystemAsset.Color.mainGreen.color
-        endBroadcastButton.setTitleColor(DesignSystemAsset.Color.mainBlack.color, for: .normal)
+        finshBroadcastButton.setTitle("방송종료", for: .normal)
+        finshBroadcastButton.layer.cornerRadius = 16
+        finshBroadcastButton.titleLabel?.font = .setFont(.body1())
+        finshBroadcastButton.backgroundColor = DesignSystemAsset.Color.mainGreen.color
+        finshBroadcastButton.setTitleColor(DesignSystemAsset.Color.mainBlack.color, for: .normal)
     }
     
     public override func setupLayouts() {
@@ -78,25 +78,25 @@ public final class BroadcastViewController: BaseViewController<SettingViewModel>
                 .centerX(to: broadcastStatusStackView)
         }
         
-        endBroadcastButton.ezl.makeConstraint {
+        finshBroadcastButton.ezl.makeConstraint {
             $0.height(56)
                 .bottom(to: view.safeAreaLayoutGuide, offset: -23)
                 .horizontal(to: view, padding: 20)
         }
         
         broadcastPicker.ezl.makeConstraint {
-            $0.center(to: endBroadcastButton)
-                .width(endBroadcastButton.frame.width)
-                .height(endBroadcastButton.frame.height)
+            $0.center(to: finshBroadcastButton)
+                .width(finshBroadcastButton.frame.width)
+                .height(finshBroadcastButton.frame.height)
         }
     }
     
     public override func setupActions() {
-        endBroadcastButton.addTarget(self, action: #selector(didTapEndButton), for: .touchUpInside)
+        finshBroadcastButton.addTarget(self, action: #selector(didTapFinishButton), for: .touchUpInside)
     }
     
     @objc
-    private func didTapEndButton() {
+    private func didTapFinishButton() {
         guard let broadcastPickerButton = broadcastPicker.subviews.first(where: { $0 is UIButton }) as? UIButton else { return }
         broadcastPickerButton.sendActions(for: .touchUpInside)
     }

--- a/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastViewController.swift
@@ -49,7 +49,9 @@ public final class BroadcastViewController: BaseViewController<SettingViewModel>
         view.addSubview(endBroadcastButton)
     }
     
-    public override func setupStyles() {        
+    public override func setupStyles() {
+        view.backgroundColor = .systemBackground
+        
         broadcastStatusStackView.axis = .vertical
         broadcastStatusStackView.spacing = 7
         broadcastStatusStackView.alignment = .center

--- a/Projects/Features/MainFeature/Sources/ViewControllers/SettingUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/SettingUIViewController.swift
@@ -64,9 +64,8 @@ public final class SettingUIViewController: BaseViewController<SettingViewModel>
             .sink { [weak self] isReady in
                 if isReady {
                     guard let broadcastPickerButton = self?.broadcastPicker.subviews.first(where: { $0 is UIButton }) as? UIButton else { return }
-                    self?.removeLoadingView()
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     broadcastPickerButton.sendActions(for: .touchUpInside)
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 } else {
                     self?.addLoadingView()
                     self?.disableButton()

--- a/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
@@ -5,31 +5,6 @@ import BaseFeatureInterface
 import BroadcastDomainInterface
 import LiveStationDomainInterface
 
-public struct Channel: Hashable {
-    let id: String
-    let name: String
-    var thumbnailImageURLString: String
-    var thumbnailImage: UIImage?
-    let owner: String
-    let description: String
-
-    public init(
-        id: String,
-        title: String,
-        thumbnailImageURLString: String = "",
-        thumbnailImage: UIImage? = nil,
-        owner: String = "",
-        description: String = ""
-    ) {
-        self.id = id
-        self.name = title
-        self.thumbnailImageURLString = thumbnailImageURLString
-        self.thumbnailImage = thumbnailImage
-        self.owner = owner
-        self.description = description
-    }
-}
-
 public class BroadcastCollectionViewModel: ViewModel {
     public struct Input {
         let fetch: PassthroughSubject<Void, Never> = .init()

--- a/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
@@ -102,7 +102,8 @@ public class BroadcastCollectionViewModel: ViewModel {
                     }
                 },
                 receiveValue: { [weak self] channels in
-                    self?.output.channels.send(channels)
+                    let filteredChannels = channels.filter { !($0.id == self?.channelID) }
+                    self?.output.channels.send(filteredChannels)
                 }
             )
             .store(in: &cancellables)

--- a/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
@@ -24,8 +24,9 @@ public class BroadcastCollectionViewModel: ViewModel {
     
     private var cancellables = Set<AnyCancellable>()
     
-    let extensionBundleID = "kr.codesquad.boostcamp9.Shook.BroadcastUploadExtension"
-    let isStreamingKey = "IS_STREAMING"
+    private let extensionBundleID = "kr.codesquad.boostcamp9.Shook.BroadcastUploadExtension"
+    private let isStreamingKey = "IS_STREAMING"
+    private let channelID = UserDefaults.standard.string(forKey: "CHANNEL_ID")
     
     public init(
         fetchChannelListUsecase: FetchChannelListUsecase,

--- a/Projects/Features/MainFeature/Sources/ViewModels/SettingViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/SettingViewModel.swift
@@ -27,9 +27,11 @@ public class SettingViewModel: ViewModel {
     
     private var broadcastName: String = ""
     private var channelDescription: String = ""
-    private var channelID = UserDefaults.standard.string(forKey: "CHANNEL_ID")
-    private let userName = UserDefaults.standard.string(forKey: "USER_NAME") ?? ""
-    private let rtmp = "RTMP_SEVICE_URL"
+    
+    private let channelID = UserDefaults.standard.string(forKey: "CHANNEL_ID")
+    private let userName = UserDefaults.standard.string(forKey: "USER_NAME")
+    
+    private let rtmpKey = "RTMP_SEVICE_URL"
     private let streamKey = "STREAMING_KEY"
 
     let sharedDefaults = UserDefaults(suiteName: "group.kr.codesquad.boostcamp9.Shook")
@@ -69,8 +71,7 @@ public class SettingViewModel: ViewModel {
         
         input.didTapStartBroadcastButton
             .flatMap { [weak self] in
-                guard let self,
-                      let channelID else { return Empty<ChannelInfoEntity, Error>().eraseToAnyPublisher() }
+                guard let self, let channelID, let userName else { return Empty<ChannelInfoEntity, Error>().eraseToAnyPublisher() }
                 output.isReadyToStream.send(false)
                 return fetchChannelInfoUsecase.execute(channelID: channelID)
                     .zip(
@@ -87,7 +88,7 @@ public class SettingViewModel: ViewModel {
             .sink { _ in
             } receiveValue: { [weak self] channelInfo in
                 guard let self else { return }
-                sharedDefaults?.set(channelInfo.rtmpUrl, forKey: rtmp)
+                sharedDefaults?.set(channelInfo.rtmpUrl, forKey: rtmpKey)
                 sharedDefaults?.set(channelInfo.streamKey, forKey: streamKey)
                 output.isReadyToStream.send(true)
             }

--- a/Projects/UserInterfaces/DesignSystem/Sources/SHLoadingView.swift
+++ b/Projects/UserInterfaces/DesignSystem/Sources/SHLoadingView.swift
@@ -3,7 +3,7 @@ import UIKit
 import Lottie
 
 public final class SHLoadingView: UIView {
-    private let message: String
+    public var message: String
     private let blurEffectView: UIVisualEffectView = {
         let blurEffect = UIBlurEffect(style: .systemUltraThinMaterialDark)
         let view = UIVisualEffectView(effect: blurEffect)


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 방송 중 화면 수정과 채널 리스트 오류를 간단하게 수정했습니다.

## 📃 작업내용

### 방송 중 화면 수정

- 뒷 배경이 `clear`가 되면서 `collectionView`가 보이는 상황을 해결했습니다.

| 문제 상황 | 문제 해결 결과 |
| -- | -- |
| <image width="250" src="https://github.com/user-attachments/assets/99d67ba4-f48a-4a4c-ab72-a1342db9c9b1"> | <image width="250" src="https://github.com/user-attachments/assets/ba946aa7-874a-469a-ac0b-df87ebc1074b"> |

### 방송이 종료되어도 자기 자신이 방송한 리스트가 불려저오는 이슈

<image width="250" src="https://github.com/user-attachments/assets/b9da9dff-d4b1-4aaa-bff3-df719a8828b4">

#### 간단하게 필터링을 통해 해결했습니다.
- 이 부분의 경우 `채널 방송 종료 → 채널 방송이 종료된 것을 확인 → 확인 후 채널리스트 다시 불러오기`보다는 `채널 방송 종료 → 채널리스트 다시 불러오기 → 채널 필터링`이 더 리소스가 적게 들 것이라고 판단했는데 어떻게 생각하시는지 궁금합니다.

```swift
                receiveValue: { [weak self] channels in
                    let filteredChannels = channels.filter { !($0.id == self?.channelID) }
                    self?.output.channels.send(filteredChannels)
                }
```

## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?
