### PR TITLE
task singletone관련 review를 반영

### DIFF
--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -71,17 +71,21 @@ extension SceneDelegate {
         let liveStreamFactoryImpl = LiveStreamViewControllerFactoryImpl(fetchBroadcastUseCase: fetchBroadcastUseCase)
         DIContainer.shared.register(LiveStreamViewControllerFactory.self, dependency: liveStreamFactoryImpl)
         
+        let broadcastState: BroadcastState = BroadcastState.shared
+        
         let settingFactoryImpl = SettingViewControllerFactoryImpl(
             fetchChannelInfoUsecase: fetchChannelInfoUsecaseImpl,
             makeBroadcastUsecase: makeBroadcastUsecaseImpl,
-            deleteBroadCastUsecase: deleteBroadCastUsecaseImpl
+            deleteBroadCastUsecase: deleteBroadCastUsecaseImpl,
+            broadcastState: broadcastState
         )
         DIContainer.shared.register(SettingViewControllerFactory.self, dependency: settingFactoryImpl)
         
         let broadcastViewControllerFactory = BroadcastViewControllerFactoryImpl(
             fetchChannelInfoUsecase: fetchChannelInfoUsecaseImpl,
             makeBroadcastUsecase: makeBroadcastUsecaseImpl,
-            deleteBroadCastUsecase: deleteBroadCastUsecaseImpl
+            deleteBroadCastUsecase: deleteBroadCastUsecaseImpl,
+            broadcastState: broadcastState
         )
         DIContainer.shared.register(BroadcastViewControllerFactory.self, dependency: broadcastViewControllerFactory)
     }

--- a/Projects/Features/MainFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/MainFeature/Demo/Sources/AppDelegate.swift
@@ -17,9 +17,11 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         let mockmakeBroadcastUsecase = MockMakeBroadcastUsecaseImpl()
         let mockFetchAllBroadcastUsecase = MockFetchAllBroadcastUsecaseImpl()
         let mockDeleteBroadcastUsecase = MockDeleteBroadcastUsecaseImpl()
+        let mockBroadcastState = MockBroadcastState()
         let viewModel = BroadcastCollectionViewModel(
             fetchChannelListUsecase: mockFetchChannelListUsecase,
-            fetchAllBroadcastUsecase: mockFetchAllBroadcastUsecase
+            fetchAllBroadcastUsecase: mockFetchAllBroadcastUsecase,
+            broadcastState: mockBroadcastState
         )
         let mockFactory = MockLiveStreamViewControllerFractoryImpl()
         let viewController = BroadcastCollectionViewController(viewModel: viewModel, factory: mockFactory)

--- a/Projects/Features/MainFeature/Demo/Sources/MockBroadcastState.swift
+++ b/Projects/Features/MainFeature/Demo/Sources/MockBroadcastState.swift
@@ -1,0 +1,7 @@
+import Combine
+
+import MainFeatureInterface
+
+final class MockBroadcastState: BroadcastStateProtocol {
+    var isBroadcasting: PassthroughSubject<Bool, Never> = .init()
+}

--- a/Projects/Features/MainFeature/Interface/BroadcastStateProtocol.swift
+++ b/Projects/Features/MainFeature/Interface/BroadcastStateProtocol.swift
@@ -1,0 +1,5 @@
+import Combine
+
+public protocol BroadcastStateProtocol {
+    var isBroadcasting: PassthroughSubject<Bool, Never> { get }
+}

--- a/Projects/Features/MainFeature/Sources/Factory/BroadcastViewControllerFactoryImpl.swift
+++ b/Projects/Features/MainFeature/Sources/Factory/BroadcastViewControllerFactoryImpl.swift
@@ -8,18 +8,21 @@ public struct BroadcastViewControllerFactoryImpl: BroadcastViewControllerFactory
     private let fetchChannelInfoUsecase: any FetchChannelInfoUsecase
     private let makeBroadcastUsecase: any MakeBroadcastUsecase
     private let deleteBroadCastUsecase: any DeleteBroadcastUsecase
+    private let broadcastState: BroadcastState
     
-    public init(fetchChannelInfoUsecase: any FetchChannelInfoUsecase, makeBroadcastUsecase: any MakeBroadcastUsecase, deleteBroadCastUsecase: any DeleteBroadcastUsecase) {
+    public init(fetchChannelInfoUsecase: any FetchChannelInfoUsecase, makeBroadcastUsecase: any MakeBroadcastUsecase, deleteBroadCastUsecase: any DeleteBroadcastUsecase, broadcastState: BroadcastState) {
         self.fetchChannelInfoUsecase = fetchChannelInfoUsecase
         self.makeBroadcastUsecase = makeBroadcastUsecase
         self.deleteBroadCastUsecase = deleteBroadCastUsecase
+        self.broadcastState = broadcastState
     }
     
     public func make() -> UIViewController {
         let viewModel = SettingViewModel(
             fetchChannelInfoUsecase: fetchChannelInfoUsecase,
             makeBroadcastUsecase: makeBroadcastUsecase,
-            deleteBroadCastUsecase: deleteBroadCastUsecase
+            deleteBroadCastUsecase: deleteBroadCastUsecase,
+            broadcastState: broadcastState
         )
         
         return BroadcastViewController(viewModel: viewModel)

--- a/Projects/Features/MainFeature/Sources/Factory/SettingViewControllerFactoryImpl.swift
+++ b/Projects/Features/MainFeature/Sources/Factory/SettingViewControllerFactoryImpl.swift
@@ -8,18 +8,21 @@ public struct SettingViewControllerFactoryImpl: SettingViewControllerFactory {
     private let fetchChannelInfoUsecase: any FetchChannelInfoUsecase
     private let makeBroadcastUsecase: any MakeBroadcastUsecase
     private let deleteBroadCastUsecase: any DeleteBroadcastUsecase
+    private let broadcastState: BroadcastState
     
-    public init(fetchChannelInfoUsecase: any FetchChannelInfoUsecase, makeBroadcastUsecase: any MakeBroadcastUsecase, deleteBroadCastUsecase: any DeleteBroadcastUsecase) {
+    public init(fetchChannelInfoUsecase: any FetchChannelInfoUsecase, makeBroadcastUsecase: any MakeBroadcastUsecase, deleteBroadCastUsecase: any DeleteBroadcastUsecase, broadcastState: BroadcastState) {
         self.fetchChannelInfoUsecase = fetchChannelInfoUsecase
         self.makeBroadcastUsecase = makeBroadcastUsecase
         self.deleteBroadCastUsecase = deleteBroadCastUsecase
+        self.broadcastState = broadcastState
     }
     
     public func make() -> UIViewController {
         let viewModel = SettingViewModel(
             fetchChannelInfoUsecase: fetchChannelInfoUsecase,
             makeBroadcastUsecase: makeBroadcastUsecase,
-            deleteBroadCastUsecase: deleteBroadCastUsecase
+            deleteBroadCastUsecase: deleteBroadCastUsecase,
+            broadcastState: broadcastState
         )
         
         return SettingUIViewController(viewModel: viewModel)

--- a/Projects/Features/MainFeature/Sources/Utilities/BroadcastState.swift
+++ b/Projects/Features/MainFeature/Sources/Utilities/BroadcastState.swift
@@ -1,7 +1,11 @@
 import Combine
 
-final class BroadcastState {
-    static let shared = BroadcastState()
+import MainFeatureInterface
+
+public final class BroadcastState: BroadcastStateProtocol {
+    public static let shared = BroadcastState()
     
-    let isBroadcasting: PassthroughSubject<Bool, Never> = .init()
+    public let isBroadcasting: PassthroughSubject<Bool, Never> = .init()
+    
+    private init() {}
 }

--- a/Projects/Features/MainFeature/Sources/ViewControllers/SettingUIViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/SettingUIViewController.swift
@@ -5,6 +5,7 @@ import UIKit
 import BaseFeature
 import DesignSystem
 import EasyLayoutModule
+import MainFeatureInterface
 
 public final class SettingUIViewController: BaseViewController<SettingViewModel> {
     deinit {
@@ -21,8 +22,22 @@ public final class SettingUIViewController: BaseViewController<SettingViewModel>
     
     private var broadcastPicker = RPSystemBroadcastPickerView()
     
+    private let broadcastState: BroadcastStateProtocol
+    
     private let viewModelInput = SettingViewModel.Input()
     private var cancellables = Set<AnyCancellable>()
+    
+    public init(
+        viewModel: SettingViewModel,
+        broadcastState: BroadcastStateProtocol = BroadcastState.shared
+    ) {
+        self.broadcastState = broadcastState
+        super.init(viewModel: viewModel)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     public override func observeValue(
         forKeyPath keyPath: String?,
@@ -150,7 +165,7 @@ public final class SettingUIViewController: BaseViewController<SettingViewModel>
     }
     
     private func didStartBroadCast() {
-        BroadcastState.shared.isBroadcasting.send(true)
+        broadcastState.isBroadcasting.send(true)
         dismiss(animated: true)
     }
     

--- a/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
@@ -4,6 +4,7 @@ import UIKit
 import BaseFeatureInterface
 import BroadcastDomainInterface
 import LiveStationDomainInterface
+import MainFeatureInterface
 
 public struct Channel: Hashable {
     let id: String
@@ -47,6 +48,8 @@ public class BroadcastCollectionViewModel: ViewModel {
     private let fetchChannelListUsecase: any FetchChannelListUsecase
     private let fetchAllBroadcastUsecase: any FetchAllBroadcastUsecase
     
+    private let broadcastState: BroadcastStateProtocol
+    
     private var cancellables = Set<AnyCancellable>()
     
     let extensionBundleID = "kr.codesquad.boostcamp9.Shook.BroadcastUploadExtension"
@@ -54,10 +57,12 @@ public class BroadcastCollectionViewModel: ViewModel {
     
     public init(
         fetchChannelListUsecase: FetchChannelListUsecase,
-        fetchAllBroadcastUsecase: FetchAllBroadcastUsecase
+        fetchAllBroadcastUsecase: FetchAllBroadcastUsecase,
+        broadcastState: BroadcastStateProtocol = BroadcastState.shared
     ) {
         self.fetchChannelListUsecase = fetchChannelListUsecase
         self.fetchAllBroadcastUsecase = fetchAllBroadcastUsecase
+        self.broadcastState = broadcastState
     }
     
     public func transform(input: Input) -> Output {
@@ -73,7 +78,7 @@ public class BroadcastCollectionViewModel: ViewModel {
             }
             .store(in: &cancellables)
         
-        BroadcastState.shared.isBroadcasting
+        broadcastState.isBroadcasting
             .sink { [weak self] isBroadcasting in
                 if isBroadcasting {
                     self?.output.showBroadcastUIView.send()

--- a/Projects/Features/MainFeature/Sources/ViewModels/SettingViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/SettingViewModel.swift
@@ -4,6 +4,7 @@ import Foundation
 import BaseFeatureInterface
 import BroadcastDomainInterface
 import LiveStationDomainInterface
+import MainFeatureInterface
 
 public class SettingViewModel: ViewModel {
     public struct Input {
@@ -25,6 +26,8 @@ public class SettingViewModel: ViewModel {
     private let makeBroadcastUsecase: any MakeBroadcastUsecase
     private let deleteBroadCastUsecase: any DeleteBroadcastUsecase
     
+    private let broadcastState: BroadcastStateProtocol
+    
     private var broadcastName: String = ""
     private var channelDescription: String = ""
     private var channelID = UserDefaults.standard.string(forKey: "CHANNEL_ID")
@@ -39,11 +42,13 @@ public class SettingViewModel: ViewModel {
     public init(
         fetchChannelInfoUsecase: FetchChannelInfoUsecase,
         makeBroadcastUsecase: MakeBroadcastUsecase,
-        deleteBroadCastUsecase: DeleteBroadcastUsecase
+        deleteBroadCastUsecase: DeleteBroadcastUsecase,
+        broadcastState: BroadcastState
     ) {
         self.fetchChannelInfoUsecase = fetchChannelInfoUsecase
         self.makeBroadcastUsecase = makeBroadcastUsecase
         self.deleteBroadCastUsecase = deleteBroadCastUsecase
+        self.broadcastState = broadcastState
     }
     
     public func transform(input: Input) -> Output {
@@ -101,8 +106,8 @@ public class SettingViewModel: ViewModel {
                     .eraseToAnyPublisher()
             }
             .sink { _ in
-            } receiveValue: { _ in
-                BroadcastState.shared.isBroadcasting.send(false)
+            } receiveValue: { [weak self] _ in
+                self?.broadcastState.isBroadcasting.send(false)
             }
             .store(in: &cancellables)
         


### PR DESCRIPTION
## 💡 요약 및 이슈 

### #278 리뷰받은 부분을 수정했습니다.

- #278

## 📃 작업내용

- 의존성 주입
- 프로토콜 추가

## 🙋‍♂️ 리뷰노트

먼저, 주말에 시간 내서 리뷰해주셔서 감사합니다.
조언해 주신 대로 싱글턴 객체를 바로 사용하지 않고, 의존성을 주입해서 사용할 수 있도록 수정했습니다.
또한 싱글턴인데 생성자에 private 접근제어자가 없는 것을 확인하여 추가했습니다.

마지막으로 현준님이 말씀해 주신 것처럼 현재 모든 곳에서 싱글턴에 접근할 수 있기 때문에 우려되는 부분이 있습니다.
하지만 이건 싱글톤이 가진 고질적인 문제가 아닐까라는 생각도 듭니다..!
그렇다면 현재 상황에서 싱글톤이 최선인가? 라는 질문에는 방송중인 상태의 경우 앱 전반에 있어서 공통적으로 필요한 상태라는 생각이 들어서 최선이지 않을까 라는 생각이 들었습니다.

혹시 제가 미처 생각하지 못한 방법이나 우려점이 추가로 있다면 코멘트 남겨주시면 남은 주말동안 다시 한 번 생각해 보도록 하겠습니다.

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
