### PR TITLE
hotfix 미등록 옵저버 할당 해제 버그 해제

### DIFF
--- a/Projects/Features/LiveStreamFeature/Sources/Player/Views/ShookPlayerView.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/Views/ShookPlayerView.swift
@@ -32,6 +32,7 @@ final class ShookPlayerView: BaseView {
     private let indicatorView: UIActivityIndicatorView =  UIActivityIndicatorView()
     private var timeObserverToken: Any?
     private var subscription: Set<AnyCancellable> = .init()
+    private var isRegisterdObsever: Bool = false
     
     // MARK: - @Published
     @Published private var playingStateChangedPublisher: Bool?
@@ -65,6 +66,7 @@ final class ShookPlayerView: BaseView {
         player.replaceCurrentItem(with: playerItem)
         addObserver()
         player.play()
+        isRegisterdObsever = true
     }
     
     required init?(coder: NSCoder) {
@@ -72,7 +74,9 @@ final class ShookPlayerView: BaseView {
     }
     
     deinit {
-        removeObserver()
+        if isRegisterdObsever {
+            removeObserver()
+        }
     }
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {


### PR DESCRIPTION
## 💡 요약 및 이슈 

방송이 종료된 후 접속하면 addObserver가 되지 않는데

이 때 방송을 나가게 되면 removeObserver가 되면서

등록되지 않은 옵저버가 해제되어 앱이 강제로 종료되는 버그가 있습니다

## 📃 작업내용

```swift
private var isRegisterObserver 
```

변수를 통해 등록 여부를 체크 후 삭제한다.

## 🙋‍♂️ 리뷰노트

- 없습니다.

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
