### PR TITLE
task hotfix 방송 설명 없을 시 Unknown 옆에 . 표시되는 문제 해결

### DIFF
--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
@@ -89,7 +89,7 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
     public override func setupStyles() {
         view.backgroundColor = .black
         
-        infoView.configureUI(with: (_title, _owner + (description.isEmpty ? " " : " • ") + _description))
+        infoView.configureUI(with: (_title, _owner + (_description.isEmpty ? " " : " • ") + _description))
         print("description: ", _description)
         bottomGuideView.backgroundColor = DesignSystemAsset.Color.darkGray.color
     }


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 방송 설명 없을 시 Unknown 옆에 . 표시되는 문제를 해결했습니다.


## 📃 작업내용

작업 전
<image width="350" src="https://github.com/user-attachments/assets/5a014ec5-7ded-4980-aeb2-7d065caef2a7">


작업 후
<image width="350" src="https://github.com/user-attachments/assets/743bee7c-740d-46f5-bb72-5e08ffe8e702">



## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
