### PR TITLE
task hotfix 레이아웃 깨지는 문제

### DIFF
--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
@@ -220,8 +220,8 @@ extension LiveStreamViewController {
     private func infoViewConstraintAnimation(_ isShowed: Bool) {
         UIView.transition(with: view, duration: 0.3, options: .curveEaseInOut) {
             if isShowed {
-                self.unfoldedConstraint?.isActive = true
                 self.foldedConstraint?.isActive = false
+                self.unfoldedConstraint?.isActive = true
             } else {
                 self.unfoldedConstraint?.isActive = false
                 self.foldedConstraint?.isActive = true


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 라이브스트리밍뷰에서 레이아웃이 깨지는 문제 해결

## 📃 작업내용

```
Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x3035f88c0 V:[LiveStreamFeature.ShookPlayerView:0x156d90500]-(0)-[LiveStreamFeature.LiveStreamInfoView:0x156d8d180]   (active)>",
    "<NSLayoutConstraint:0x3035f4c30 V:|-(20)-[UIStackView:0x156d8d340]   (active, names: '|':LiveStreamFeature.LiveStreamInfoView:0x156d8d180 )>",
    "<NSLayoutConstraint:0x3035f4c80 UIStackView:0x156d8d340.bottom == LiveStreamFeature.LiveStreamInfoView:0x156d8d180.bottom - 20   (active)>",
    "<NSLayoutConstraint:0x3035f8910 LiveStreamFeature.LiveStreamInfoView:0x156d8d180.bottom == LiveStreamFeature.ShookPlayerView:0x156d90500.bottom   (active)>"
)
```

기존에 플레이어뷰를 터치하면 info뷰가 보이면서 위와같이 레이아웃이 깨지는 문제가 발생했습니다

## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
