### PR TITLE
fix 종료된 방송 접속 시 경고 팝업 띄우기

### DIFF
--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
@@ -195,18 +195,25 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
             .store(in: &subscription)
         
         output.videoURLString
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] urlString in
-                guard let self, let url = URL(string: urlString) else { return }
-                DispatchQueue.main.async {
-                    self.playerView.fetchVideo(m3u8URL: url)
-                }
+                guard let self ,let url = URL(string: urlString) else { return }
+                self.playerView.fetchVideo(m3u8URL: url)
+                
+            }
+            .store(in: &subscription)
+        
+        output.showAlert
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.showDissmissAlert()
             }
             .store(in: &subscription)
     }
 }
 
 extension LiveStreamViewController {
-    func changeOrientation() {
+    private func changeOrientation() {
         let orientation: UIInterfaceOrientationMask = output.isExpanded.value ? .landscapeLeft: .portrait
         
         if #available(iOS 16.0, *) {
@@ -229,6 +236,16 @@ extension LiveStreamViewController {
             }
             self.view.layoutIfNeeded()
         }
+    }
+    
+    private func showDissmissAlert() {
+        let alert = UIAlertController(title: "방송 알림", message: "이미 종료된 방송입니다.", preferredStyle: .alert)
+        let action = UIAlertAction(title: "확인", style: .destructive) { [weak self] _ in
+            guard let self else { return }
+            self.dismiss(animated: true)
+        }
+        alert.addAction(action)
+        present(alert, animated: true)
     }
 }
 


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 종료된 방송에 입장 시 검은 화면만 보이는 상황이 있습니다.

## 📃 작업내용

### usecase에 failure가 들어왔을 때 경고창을 띄운 후 확인을 누르면 dismiss 처리를합니다.


## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
