### PR TITLE
task 썸네일 이미지 불러오기 개선

### DIFF
--- a/Projects/Features/MainFeature/Sources/Models/Channel.swift
+++ b/Projects/Features/MainFeature/Sources/Models/Channel.swift
@@ -4,7 +4,6 @@ public struct Channel: Hashable {
     let id: String
     let name: String
     var thumbnailImageURLString: String
-    var thumbnailImage: UIImage?
     let owner: String
     let description: String
 
@@ -12,14 +11,12 @@ public struct Channel: Hashable {
         id: String,
         title: String,
         thumbnailImageURLString: String = "",
-        thumbnailImage: UIImage? = nil,
         owner: String = "",
         description: String = ""
     ) {
         self.id = id
         self.name = title
         self.thumbnailImageURLString = thumbnailImageURLString
-        self.thumbnailImage = thumbnailImage
         self.owner = owner
         self.description = description
     }

--- a/Projects/Features/MainFeature/Sources/Models/Channel.swift
+++ b/Projects/Features/MainFeature/Sources/Models/Channel.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 public struct Channel: Hashable {
     let id: String
     let name: String

--- a/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastCollectionViewController.swift
@@ -111,6 +111,7 @@ public class BroadcastCollectionViewController: BaseViewController<BroadcastColl
             .receive(on: DispatchQueue.main)
             .sink { [weak self] channels in
                 self?.applySnapshot(with: channels)
+                self?.refreshControl.endRefreshing()
             }
             .store(in: &cancellables)
         
@@ -280,11 +281,7 @@ extension BroadcastCollectionViewController {
             }
         }
         
-        dataSource?.applySnapshotUsingReloadData(snapshot) { [weak self] in
-            if self?.refreshControl.isRefreshing == true {
-                self?.refreshControl.endRefreshing()
-            }
-        }
+        dataSource?.applySnapshotUsingReloadData(snapshot)
     }
 }
 

--- a/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastCollectionViewController.swift
+++ b/Projects/Features/MainFeature/Sources/ViewControllers/BroadcastCollectionViewController.swift
@@ -280,7 +280,7 @@ extension BroadcastCollectionViewController {
             }
         }
         
-        dataSource?.apply(snapshot, animatingDifferences: true) { [weak self] in
+        dataSource?.applySnapshotUsingReloadData(snapshot) { [weak self] in
             if self?.refreshControl.isRefreshing == true {
                 self?.refreshControl.endRefreshing()
             }

--- a/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
+++ b/Projects/Features/MainFeature/Sources/ViewModels/BroadcastCollectionViewModel.swift
@@ -70,7 +70,7 @@ public class BroadcastCollectionViewModel: ViewModel {
     private func fetchData() {
         fetchChannelListUsecase.execute()
             .zip(fetchAllBroadcastUsecase.execute())
-            .map { channelEntities, broadcastInfoEntities -> [Channel] in
+            .map { channelEntities, broadcastInfoEntities in
                 channelEntities.map { channelEntity in
                     let broadcast = broadcastInfoEntities.first { $0.id == channelEntity.id }
                     return Channel(
@@ -82,44 +82,13 @@ public class BroadcastCollectionViewModel: ViewModel {
                     )
                 }
             }
-            .flatMap { [weak self] channels -> AnyPublisher<[Channel], Never> in
-                guard let self else { return Just([]).eraseToAnyPublisher() }
-
-                return channels.publisher
-                    .flatMap { channel -> AnyPublisher<Channel, Never> in
-                        self.loadAsyncImage(with: channel.thumbnailImageURLString)
-                            .replaceError(with: nil)
-                            .map { image in
-                                var updatedChannel = channel
-                                updatedChannel.thumbnailImage = image
-                                return updatedChannel
-                            }
-                            .eraseToAnyPublisher()
-                    }
-                    .collect()
-                    .eraseToAnyPublisher()
-            }
             .sink(
-                receiveCompletion: { completion in
-                    switch completion {
-                    case .finished: break
-                    case .failure(let error): print("Error: \(error)")
-                    }
-                },
+                receiveCompletion: { _ in },
                 receiveValue: { [weak self] channels in
                     let filteredChannels = channels.filter { !($0.id == self?.channelID) }
                     self?.output.channels.send(filteredChannels)
                 }
             )
             .store(in: &cancellables)
-    }
-    
-    private func loadAsyncImage(with imageURLString: String) -> AnyPublisher<UIImage?, URLError> {
-        guard let url = URL(string: imageURLString) else {
-            return Just(nil).setFailureType(to: URLError.self).eraseToAnyPublisher()
-        }
-        return URLSession.shared.dataTaskPublisher(for: url)
-            .map { data, _ in UIImage(data: data) }
-            .eraseToAnyPublisher()
     }
 }

--- a/Projects/Features/MainFeature/Sources/Views/BroadcastCollectionViewCell/LargeBroadcastCollectionViewCell.swift
+++ b/Projects/Features/MainFeature/Sources/Views/BroadcastCollectionViewCell/LargeBroadcastCollectionViewCell.swift
@@ -63,19 +63,8 @@ final class LargeBroadcastCollectionViewCell: BaseCollectionViewCell, ThumbnailV
     }
     
     func configure(channel: Channel) {
-        loadAsyncImage(with: channel.thumbnailImageURLString)
+        self.thumbnailView.configure(with: channel.thumbnailImageURLString)
         self.titleLabel.text = channel.name
         self.descriptionLabel.text = channel.owner + (channel.description.isEmpty ? "" : " • \(channel.description)")
-    }
-    
-    private func loadAsyncImage(with imageURLString: String) {
-        guard let url = URL(string: imageURLString) else { return }
-        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
-            guard error == nil,
-                  let data else { return }
-            DispatchQueue.main.async {
-                self?.thumbnailView.configure(with: UIImage(data: data))
-            }
-        }.resume()
     }
 }

--- a/Projects/Features/MainFeature/Sources/Views/BroadcastCollectionViewCell/LargeBroadcastCollectionViewCell.swift
+++ b/Projects/Features/MainFeature/Sources/Views/BroadcastCollectionViewCell/LargeBroadcastCollectionViewCell.swift
@@ -63,8 +63,19 @@ final class LargeBroadcastCollectionViewCell: BaseCollectionViewCell, ThumbnailV
     }
     
     func configure(channel: Channel) {
-        self.thumbnailView.configure(with: channel.thumbnailImage)
+        loadAsyncImage(with: channel.thumbnailImageURLString)
         self.titleLabel.text = channel.name
         self.descriptionLabel.text = channel.owner + (channel.description.isEmpty ? "" : " • \(channel.description)")
+    }
+    
+    private func loadAsyncImage(with imageURLString: String) {
+        guard let url = URL(string: imageURLString) else { return }
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
+            guard error == nil,
+                  let data else { return }
+            DispatchQueue.main.async {
+                self?.thumbnailView.configure(with: UIImage(data: data))
+            }
+        }.resume()
     }
 }

--- a/Projects/Features/MainFeature/Sources/Views/BroadcastCollectionViewCell/SmallBroadcastCollectionViewCell.swift
+++ b/Projects/Features/MainFeature/Sources/Views/BroadcastCollectionViewCell/SmallBroadcastCollectionViewCell.swift
@@ -68,20 +68,9 @@ final class SmallBroadcastCollectionViewCell: BaseCollectionViewCell, ThumbnailV
     }
     
     func configure(channel: Channel) {
-        loadAsyncImage(with: channel.thumbnailImageURLString)
+        self.thumbnailView.configure(with: channel.thumbnailImageURLString)
         self.titleLabel.text = channel.name
         self.ownerLabel.text = channel.owner
         self.descriptionLabel.text = channel.description
-    }
-    
-    private func loadAsyncImage(with imageURLString: String) {
-        guard let url = URL(string: imageURLString) else { return }
-        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
-            guard error == nil,
-                  let data else { return }
-            DispatchQueue.main.async {
-                self?.thumbnailView.configure(with: UIImage(data: data))
-            }
-        }.resume()
     }
 }

--- a/Projects/Features/MainFeature/Sources/Views/BroadcastCollectionViewCell/SmallBroadcastCollectionViewCell.swift
+++ b/Projects/Features/MainFeature/Sources/Views/BroadcastCollectionViewCell/SmallBroadcastCollectionViewCell.swift
@@ -68,9 +68,20 @@ final class SmallBroadcastCollectionViewCell: BaseCollectionViewCell, ThumbnailV
     }
     
     func configure(channel: Channel) {
-        self.thumbnailView.configure(with: channel.thumbnailImage)
+        loadAsyncImage(with: channel.thumbnailImageURLString)
         self.titleLabel.text = channel.name
         self.ownerLabel.text = channel.owner
         self.descriptionLabel.text = channel.description
+    }
+    
+    private func loadAsyncImage(with imageURLString: String) {
+        guard let url = URL(string: imageURLString) else { return }
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
+            guard error == nil,
+                  let data else { return }
+            DispatchQueue.main.async {
+                self?.thumbnailView.configure(with: UIImage(data: data))
+            }
+        }.resume()
     }
 }

--- a/Projects/Features/MainFeature/Sources/Views/BroadcastThumbnailView.swift
+++ b/Projects/Features/MainFeature/Sources/Views/BroadcastThumbnailView.swift
@@ -75,6 +75,16 @@ final class ThumbnailView: BaseView {
         }
     }
     
+    func configure(with imageURLString: String) {
+        guard let url = URL(string: imageURLString) else { return }
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+            guard let data else { return }
+            DispatchQueue.main.async {
+                self?.imageView.image = UIImage(data: data)
+            }
+        }.resume()
+    }
+    
     func configure(with image: UIImage?) {
         imageView.image = image
     }


### PR DESCRIPTION
## 💡 요약 및 이슈 

### 썸네일 이미지를 불러오는 로직을 개선했습니다.

## 📃 작업내용

- 모든 이미지를 그때그때 받아보다보니 속도 저하 문제가 생겼습니다.

<img width="600" src="https://github.com/user-attachments/assets/7649324a-c77e-4c71-8b62-a65eec748339">

### 🧑🏻‍💻 `URLString`만 받아와서 셀 업데이트를 무조건 하게 하자!

- 데이터를 받아온다면 무조건 `reload`하는 방식을 채택해보았습니다. `Channel`의 `image`속성도 지웠습니다.

| 썸네일 바꾸기 성공! |
| -- |
| <img width="800" src="https://github.com/user-attachments/assets/96d95b48-b740-492e-8450-0d64633cd623"> |

```swift
// 변경 전
dataSource.?.apply(snapshot, animatingDifferences: true)

// 변경 후
dataSource?.applySnapshotUsingReloadData(snapshot)
```

- 기존에 `Cell`이 이미지를 로드하는 방식을 다시 가져오기로 했습니다. [관련 PR](https://github.com/boostcampwm-2024/iOS08-Shook/pull/228)
- `URLString`을 받아오면 각 `Cell`이 이미지를 로드하는 방식이 합리적인 방법이라고 느껴졌습니다.

```swift
    // 각 셀에서 일어나는 일들
    func configure(channel: Channel) {
        loadAsyncImage(with: channel.thumbnailImageURLString)
        self.titleLabel.text = channel.name
        self.descriptionLabel.text = channel.owner + (channel.description.isEmpty ? "" : " • \(channel.description)")
    }
    
    private func loadAsyncImage(with imageURLString: String) {
        guard let url = URL(string: imageURLString) else { return }
        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
            guard error == nil,
                  let data else { return }
            DispatchQueue.main.async {
                self?.thumbnailView.configure(with: UIImage(data: data))
            }
        }.resume()
    }
```

### 👀 새로 생긴 고민 상황
- `applySnapshotUsingReloadData`를 살펴보면 당연하게도 `without computing a diff or animating the changes` 라는 말이 있었습니다.
- `reloadData()`와 똑같이 작동하는 듯 보였습니다...

<img width="600" src="https://github.com/user-attachments/assets/93a0bb6b-0e5c-42ba-b816-31e8a3541d03">

#### 🤔 잠깐만... `apply`와 차이를 보면 성능에 큰 영향이 있을까?

- 가장 궁금했던건 얼마나 성능 차이가 날까? 라는 궁금증이었습니다. 왜냐하면 applySnapshotUsingReloadData의 경우 `Reset UI`를 한다는 이야기가 있어 콜렉션뷰를 다시 그린다고 이해했기 때문에 리소스 차이가 얼마나 클까 하는 궁금증 이었습니다.
- 방송을 2개 띄운 후 테스트를 진행해봤습니다.

- CPU: 아무래도 image를 다시 받아오니까 CPU 사용량이 많을 수 밖에 없습니다. 51% → 58%

| 방식 | apply | applySnapshotUsingReloadData | 
| -- | -- | -- |
| CPU | <img width="700" src="https://github.com/user-attachments/assets/62b1b6c0-274d-4a70-956f-d8a7ed6b885b"> | <img width="700" src="https://github.com/user-attachments/assets/dc6df006-f3bd-41c1-9ee3-bed26f830cf1"> |

- 메모리: 약 1.50% 증가했습니다. 이미지를 받아오고 새로 로드하는 과정 + UI를 다시 그리는 과정에서 차이가 있는 것 같습니다.

| 방식 | apply | applySnapshotUsingReloadData | 
| -- | -- | -- |
| 메모리 | <img width="700" src="https://github.com/user-attachments/assets/c60b96c6-73a4-4709-a838-474b100a335c"> | <img width="700" src="https://github.com/user-attachments/assets/f8482667-604b-4d79-ac20-3aced08cc28d"> |

- 네트워크: 당연히 바뀐 썸네일 이미지를 받아와야 하니까 네트워크가 주기적으로 쓰이네요.

| 방식 | apply | applySnapshotUsingReloadData | 
| -- | -- | -- |
| 네트워크 | <img width="700" src="https://github.com/user-attachments/assets/4c4155e7-cfd6-4cd8-b560-dbd1fadf08db"> | <img width="700" src="https://github.com/user-attachments/assets/a85ff061-6991-4a1a-a6b7-936350e19bbf"> |

- 결론: 이미지를 새로 로드하는 것 정도 차이가 난다...? 어메이징하게 크게 차이는 나지 않는다...?

#### 🥹 `DiffableDataSource`의 의미가 퇴색되었다.

- 부드러운 애니메이션... 은 고사하고, `DiffableDataSource`를 활용하여 이미 만들어진 셀을 재사용하면서 변경된 데이터만 업데이트하고 싶었는데... 이미지를 변경해야 하기 때문에 모든 셀을 다시 그려야하는 방식인 `applySnapshotUsingReloadData`를 사용한 순간 `DiffableDataSource` 왜 쓰지? 라는 생각이 들었습니다.

- 제가 원하는 방향은 이미지가 바뀔 때에만 `apply snapshot`을 하고 싶었습니다. 그렇게 된다면 셀을 업데이트 할때 바뀐 썸네일만 다시 그리니까 이미지를 다시 그리는 리소스도 줄어들 것이라고 생각했습니다.

- `Building High-Performance Lists and Collection Views`...라는 멋진 것을 발견했지만... 딥다이브하다가 실패했습니다 🥹 우선 중복 코드만 개선했습니다...

[관련 공식 문서](https://developer.apple.com/documentation/uikit/uiimage/building_high-performance_lists_and_collection_views)  
[관련 WWDC영상](https://developer.apple.com/videos/play/wwdc2021/10252/?time=915)

## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?
