### PR TITLE
task hotfix chatting UI 개선

### DIFF
--- a/Projects/Features/LiveStreamFeature/Sources/Chating/Views/ChattingListView.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Chating/Views/ChattingListView.swift
@@ -18,6 +18,7 @@ final class ChattingListView: BaseView {
     private let recentChatButton = UIButton()
     
     @Published private var isScrollFixed = true
+    private var isAnimating = false
     
     private var recentChatButtonShowConstraints: [NSLayoutConstraint] = []
     private var recentChatButtonHideConstraints: [NSLayoutConstraint] = []
@@ -61,7 +62,6 @@ final class ChattingListView: BaseView {
         chatListView.register(ChattingCell.self, forCellReuseIdentifier: ChattingCell.identifier)
         chatListView.register(SystemAlarmCell.self, forCellReuseIdentifier: SystemAlarmCell.identifier)
         chatListView.backgroundView = chatEmptyView
-        chatListView.bounces = false
     }
     
     override func setupStyles() {
@@ -125,8 +125,8 @@ final class ChattingListView: BaseView {
         
         recentChatButton.addAction(
             UIAction { [weak self] _ in
-                self?.updateRecentChatButtonConstraint(isHidden: true)
                 self?.scrollToBottom()
+                self?.updateRecentChatButtonConstraint(isHidden: true)
             },
             for: .touchUpInside
         )
@@ -146,6 +146,7 @@ final class ChattingListView: BaseView {
     
     private func scrollToBottom() {
         guard let indexPath = lastIndexPath() else { return }
+        isAnimating = true
         chatListView.scrollToRow(at: indexPath, at: .bottom, animated: true)
     }
     
@@ -189,9 +190,13 @@ extension ChattingListView: ChatInputFieldAction {
 }
 
 extension ChattingListView: UITableViewDelegate {
-    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        guard let lastIndexPath = lastIndexPath(),
-              let indexPathList = chatListView.indexPathsForVisibleRows else { return }
-        isScrollFixed = indexPathList.contains(lastIndexPath)
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard !isAnimating else { return }
+        let offsetMaxY = scrollView.contentSize.height - scrollView.bounds.height
+        isScrollFixed = (offsetMaxY - 50...offsetMaxY) ~= scrollView.contentOffset.y || offsetMaxY < scrollView.contentOffset.y
+    }
+    
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        isAnimating = false
     }
 }

--- a/Projects/Features/LiveStreamFeature/Sources/Chating/Views/ChattingListView.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Chating/Views/ChattingListView.swift
@@ -10,6 +10,7 @@ protocol ChatInputFieldAction {
 }
 
 final class ChattingListView: BaseView {
+    private let chattingContainerView = UIView()
     private let titleLabel = UILabel()
     private let chatListView = UITableView(frame: .zero, style: .plain)
     private let chatEmptyView = ChatEmptyView()
@@ -48,8 +49,9 @@ final class ChattingListView: BaseView {
     }
     
     override func setupViews() {
-        addSubview(titleLabel)
-        addSubview(chatListView)
+        addSubview(chattingContainerView)
+        chattingContainerView.addSubview(titleLabel)
+        chattingContainerView.addSubview(chatListView)
         addSubview(recentChatButton)
         addSubview(chatInputField)
         
@@ -77,15 +79,21 @@ final class ChattingListView: BaseView {
     }
     
     override func setupLayouts() {
+        chattingContainerView.ezl.makeConstraint {
+            $0.horizontal(to: self)
+                .top(to: self)
+                .bottom(to: chatInputField.ezl.top)
+        }
+        
         titleLabel.ezl.makeConstraint {
-            $0.top(to: self)
-                .leading(to: self, offset: 20)
+            $0.top(to: chattingContainerView, offset: 24)
+                .leading(to: chattingContainerView, offset: 20)
         }
         
         chatListView.ezl.makeConstraint {
-            $0.horizontal(to: self)
+            $0.horizontal(to: chattingContainerView)
                 .top(to: titleLabel.ezl.bottom, offset: 21)
-                .bottom(to: chatInputField.ezl.top)
+                .bottom(to: chattingContainerView)
         }
         
         chatInputField.ezl.makeConstraint {
@@ -107,7 +115,7 @@ final class ChattingListView: BaseView {
     
     override func setupActions() {
         let tapGesture: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
-        self.addGestureRecognizer(tapGesture)
+        chattingContainerView.addGestureRecognizer(tapGesture)
         
         $isScrollFixed
             .sink { [weak self] in

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
@@ -117,7 +117,7 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
         }
         
         chattingList.ezl.makeConstraint {
-            $0.top(to: infoView.ezl.bottom, offset: 24)
+            $0.top(to: infoView.ezl.bottom)
                 .horizontal(to: view)
                 .bottom(to: view.keyboardLayoutGuide.ezl.top)
         }

--- a/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
+++ b/Projects/Features/LiveStreamFeature/Sources/Player/ViewControllers/LiveStreamViewController.swift
@@ -133,6 +133,12 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture))
         playerView.addGestureRecognizer(panGesture)
         playerView.isUserInteractionEnabled = true
+        
+        playerView.playerGestureDidTap
+            .sink { [weak self] _ in
+                self?.view.endEditing(true)
+            }
+            .store(in: &subscription)
     }
     
     public override func setupBind() {
@@ -158,7 +164,6 @@ public final class LiveStreamViewController: BaseViewController<LiveStreamViewMo
             .sink { [weak self] flag in
                 guard let self else { return }
                 self.playerView.playerControlViewAlphaAnimalation(flag)
-                view.endEditing(true)
             }
             .store(in: &subscription)
         


### PR DESCRIPTION
## 💡 요약 및 이슈 

### hotfix chatting UI 개선

## 📃 작업내용

-  chatInputField TapGestureRecognizer 제외
- PlayerControl 애니메이션 시 키보드 내려가는 문제 수정
- 채팅 스크롤 시 `최근 채팅으로 이동` 버튼 애니메이션 개선

## 🙋‍♂️ 리뷰노트

`최근 채팅으로 이동` 버튼 클릭 시 혹은 높이가 큰 채팅 입력 시 `최근 채팅으로 이동` 애니메이션이 부자연스러운 문제 발생

|`최근 채팅으로 이동` 버튼 클릭|높이가 큰 채팅 입력|
|-|-|
|<img src="https://github.com/user-attachments/assets/245d406b-62d2-4fed-83c5-351cae425901" width=150>|<img src="https://github.com/user-attachments/assets/3e4ff237-859e-4a2e-b542-19de1d7b3629" width=150>|

해당 문제의 원인은 scrollViewDidScroll 메서드가 스크롤이 내려가는 애니메이션 중에도 호출되어 버튼 애니메이션이 고장나는 문제로 확인되었습니다.

```swift
func scrollViewDidScroll(_ scrollView: UIScrollView) {
    guard let lastIndexPath = lastIndexPath(),
          let indexPathList = chatListView.indexPathsForVisibleRows else { return }
    isScrollFixed = indexPathList.contains(lastIndexPath)
}
```

위 문제는 [해당 PR](https://github.com/boostcampwm-2024/iOS08-Shook/pull/291)에서
`scrollViewDidScroll` -> `scrollViewDidEndDecelerating`로 수정하면서 해결되었습니다. 하지만, `scrollViewDidEndDecelerating` 메서드는 사용자가 빠르게 스크롤하면서 생긴 가속도가 멈췄을 때 호출되는 메서드로 만약, 사용자가 천천히 스크롤 할 경우 호출되지 않는 문제가 추가적으로 발생하였습니다.

때문에, 이번 PR에서 `scrollViewDidEndDecelerating` -> `scrollViewDidScroll`로 다시 수정 후 기존 스크롤 에니메이션 중 `scrollViewDidScroll` 메서드가 호출되는 문제를 해결하기 위해 `isAnimating`를 추가였습니다.

```swift
    private var isAnimating = false // 스크롤 에니메이션 중인지 체크하는 변수

    private func scrollToBottom() {
        guard let indexPath = lastIndexPath() else { return }
        isAnimating = true
        chatListView.scrollToRow(at: indexPath, at: .bottom, animated: true)
    }
```
스크롤 에니메이션이 발생하는 코드 호출 전에 `isAnimating = true`로 설정하여 

``` swift
    func scrollViewDidScroll(_ scrollView: UIScrollView) {
        guard !isAnimating else { return }
        let offsetMaxY = scrollView.contentSize.height - scrollView.bounds.height
        isScrollFixed = (offsetMaxY - 50...offsetMaxY) ~= scrollView.contentOffset.y || offsetMaxY < scrollView.contentOffset.y
    }
```
`scrollViewDidScroll` 내부에서 `isAnimating = true` 인 경우 다음 작업을 무시하도록 구현하였습니다.

추가로, 
```swift
    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) { // 스크롤 에니메이션이 끝나면 호출되는 Delegate 메서드
        isAnimating = false
    }
```
`scrollViewDidEndScrollingAnimation` 내부에서 `isAnimating = false`로 설정하여 애니메이션이 끝난 후 다시 정상 동작하도록 구현하였습니다.

- 해결된 화면

|`최근 채팅으로 이동` 버튼 클릭|높이가 큰 채팅 입력|
|-|-|
|<img src="https://github.com/user-attachments/assets/2d519386-575c-4608-9602-123891b9374a" width=150>|<img src="https://github.com/user-attachments/assets/9d38eeb7-73a4-41c5-a0e0-7ad14045aae7" width=150>|



## ✅ PR 체크리스트

<!--

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
